### PR TITLE
Add language codes to admin1 in Slovenia

### DIFF
--- a/data/110/895/946/5/1108959465.geojson
+++ b/data/110/895/946/5/1108959465.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959465,
-    "wof:lastmodified":1566644825,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054581,
     "wof:name":"Novo mesto",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/946/7/1108959467.geojson
+++ b/data/110/895/946/7/1108959467.geojson
@@ -63,7 +63,13 @@
         }
     ],
     "wof:id":1108959467,
-    "wof:lastmodified":1566644824,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054581,
     "wof:name":"Mislinja",
     "wof:parent_id":1108959955,
     "wof:placetype":"localadmin",

--- a/data/110/895/946/9/1108959469.geojson
+++ b/data/110/895/946/9/1108959469.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959469,
-    "wof:lastmodified":1566644824,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054581,
     "wof:name":"Kungota",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/947/3/1108959473.geojson
+++ b/data/110/895/947/3/1108959473.geojson
@@ -159,7 +159,13 @@
         }
     ],
     "wof:id":1108959473,
-    "wof:lastmodified":1566644828,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054582,
     "wof:name":"Kr\u0161ko",
     "wof:parent_id":1108959965,
     "wof:placetype":"localadmin",

--- a/data/110/895/947/5/1108959475.geojson
+++ b/data/110/895/947/5/1108959475.geojson
@@ -150,7 +150,13 @@
         }
     ],
     "wof:id":1108959475,
-    "wof:lastmodified":1566644828,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054582,
     "wof:name":"Lendava",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/947/7/1108959477.geojson
+++ b/data/110/895/947/7/1108959477.geojson
@@ -63,7 +63,13 @@
         }
     ],
     "wof:id":1108959477,
-    "wof:lastmodified":1566644828,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054582,
     "wof:name":"Lenart",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/947/9/1108959479.geojson
+++ b/data/110/895/947/9/1108959479.geojson
@@ -117,7 +117,13 @@
         }
     ],
     "wof:id":1108959479,
-    "wof:lastmodified":1566644827,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054582,
     "wof:name":"Me\u017eica",
     "wof:parent_id":1108959955,
     "wof:placetype":"localadmin",

--- a/data/110/895/948/1/1108959481.geojson
+++ b/data/110/895/948/1/1108959481.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959481,
-    "wof:lastmodified":1566644816,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054578,
     "wof:name":"Miren-Kostanjevica",
     "wof:parent_id":1108959947,
     "wof:placetype":"localadmin",

--- a/data/110/895/948/3/1108959483.geojson
+++ b/data/110/895/948/3/1108959483.geojson
@@ -186,7 +186,13 @@
         }
     ],
     "wof:id":1108959483,
-    "wof:lastmodified":1566644816,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054578,
     "wof:name":"Murska Sobota",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/948/5/1108959485.geojson
+++ b/data/110/895/948/5/1108959485.geojson
@@ -111,7 +111,13 @@
         }
     ],
     "wof:id":1108959485,
-    "wof:lastmodified":1566644816,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054579,
     "wof:name":"Mozirje",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/948/7/1108959487.geojson
+++ b/data/110/895/948/7/1108959487.geojson
@@ -195,7 +195,13 @@
         }
     ],
     "wof:id":1108959487,
-    "wof:lastmodified":1566644815,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054578,
     "wof:name":"Nova Gorica",
     "wof:parent_id":1108959947,
     "wof:placetype":"localadmin",

--- a/data/110/895/949/1/1108959491.geojson
+++ b/data/110/895/949/1/1108959491.geojson
@@ -75,7 +75,13 @@
         }
     ],
     "wof:id":1108959491,
-    "wof:lastmodified":1566644832,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054584,
     "wof:name":"Maj\u0161perk",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/949/3/1108959493.geojson
+++ b/data/110/895/949/3/1108959493.geojson
@@ -75,7 +75,13 @@
         }
     ],
     "wof:id":1108959493,
-    "wof:lastmodified":1566644833,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054584,
     "wof:name":"Cerklje na Gorenjskem",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/949/5/1108959495.geojson
+++ b/data/110/895/949/5/1108959495.geojson
@@ -126,7 +126,13 @@
         }
     ],
     "wof:id":1108959495,
-    "wof:lastmodified":1566644833,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054584,
     "wof:name":"Dravograd",
     "wof:parent_id":1108959955,
     "wof:placetype":"localadmin",

--- a/data/110/895/949/7/1108959497.geojson
+++ b/data/110/895/949/7/1108959497.geojson
@@ -78,7 +78,13 @@
         }
     ],
     "wof:id":1108959497,
-    "wof:lastmodified":1566644832,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054584,
     "wof:name":"Naklo",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/949/9/1108959499.geojson
+++ b/data/110/895/949/9/1108959499.geojson
@@ -87,7 +87,13 @@
         }
     ],
     "wof:id":1108959499,
-    "wof:lastmodified":1566644832,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054583,
     "wof:name":"Ljutomer",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/950/1/1108959501.geojson
+++ b/data/110/895/950/1/1108959501.geojson
@@ -486,7 +486,13 @@
         }
     ],
     "wof:id":1108959501,
-    "wof:lastmodified":1566644837,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054585,
     "wof:name":"Ljubljana",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/950/3/1108959503.geojson
+++ b/data/110/895/950/3/1108959503.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959503,
-    "wof:lastmodified":1566644838,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054585,
     "wof:name":"Ljubno",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/950/5/1108959505.geojson
+++ b/data/110/895/950/5/1108959505.geojson
@@ -75,7 +75,13 @@
         }
     ],
     "wof:id":1108959505,
-    "wof:lastmodified":1566644838,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054585,
     "wof:name":"Lu\u010de",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/950/9/1108959509.geojson
+++ b/data/110/895/950/9/1108959509.geojson
@@ -87,7 +87,13 @@
         }
     ],
     "wof:id":1108959509,
-    "wof:lastmodified":1566644837,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054585,
     "wof:name":"Menge\u0161",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/951/1/1108959511.geojson
+++ b/data/110/895/951/1/1108959511.geojson
@@ -78,7 +78,13 @@
         }
     ],
     "wof:id":1108959511,
-    "wof:lastmodified":1566644869,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054596,
     "wof:name":"Kuzma",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/951/3/1108959513.geojson
+++ b/data/110/895/951/3/1108959513.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959513,
-    "wof:lastmodified":1566644869,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054596,
     "wof:name":"Lo\u0161ki Potok",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/951/5/1108959515.geojson
+++ b/data/110/895/951/5/1108959515.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959515,
-    "wof:lastmodified":1566644869,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054596,
     "wof:name":"Morav\u010de",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/951/7/1108959517.geojson
+++ b/data/110/895/951/7/1108959517.geojson
@@ -117,7 +117,13 @@
         }
     ],
     "wof:id":1108959517,
-    "wof:lastmodified":1566644869,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054596,
     "wof:name":"Beltinci",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/951/9/1108959519.geojson
+++ b/data/110/895/951/9/1108959519.geojson
@@ -102,7 +102,13 @@
         }
     ],
     "wof:id":1108959519,
-    "wof:lastmodified":1566644869,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054596,
     "wof:name":"Ti\u0161ina",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/952/1/1108959521.geojson
+++ b/data/110/895/952/1/1108959521.geojson
@@ -114,7 +114,13 @@
         }
     ],
     "wof:id":1108959521,
-    "wof:lastmodified":1566644812,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054577,
     "wof:name":"Kobilje",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/952/3/1108959523.geojson
+++ b/data/110/895/952/3/1108959523.geojson
@@ -144,7 +144,13 @@
         }
     ],
     "wof:id":1108959523,
-    "wof:lastmodified":1566644812,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054577,
     "wof:name":"Kobarid",
     "wof:parent_id":1108959947,
     "wof:placetype":"localadmin",

--- a/data/110/895/952/7/1108959527.geojson
+++ b/data/110/895/952/7/1108959527.geojson
@@ -219,7 +219,13 @@
         }
     ],
     "wof:id":1108959527,
-    "wof:lastmodified":1566644811,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054577,
     "wof:name":"Koper",
     "wof:parent_id":1108959951,
     "wof:placetype":"localadmin",

--- a/data/110/895/952/9/1108959529.geojson
+++ b/data/110/895/952/9/1108959529.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959529,
-    "wof:lastmodified":1566644811,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054577,
     "wof:name":"Duplek",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/953/1/1108959531.geojson
+++ b/data/110/895/953/1/1108959531.geojson
@@ -102,7 +102,13 @@
         }
     ],
     "wof:id":1108959531,
-    "wof:lastmodified":1566644795,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054572,
     "wof:name":"Gornji Petrovci",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/953/3/1108959533.geojson
+++ b/data/110/895/953/3/1108959533.geojson
@@ -114,7 +114,13 @@
         }
     ],
     "wof:id":1108959533,
-    "wof:lastmodified":1566644795,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054572,
     "wof:name":"Grosuplje",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/953/5/1108959535.geojson
+++ b/data/110/895/953/5/1108959535.geojson
@@ -156,7 +156,13 @@
         }
     ],
     "wof:id":1108959535,
-    "wof:lastmodified":1566644795,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054572,
     "wof:name":"Idrija",
     "wof:parent_id":1108959947,
     "wof:placetype":"localadmin",

--- a/data/110/895/953/7/1108959537.geojson
+++ b/data/110/895/953/7/1108959537.geojson
@@ -126,7 +126,13 @@
         }
     ],
     "wof:id":1108959537,
-    "wof:lastmodified":1566644794,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054572,
     "wof:name":"Kanal",
     "wof:parent_id":1108959947,
     "wof:placetype":"localadmin",

--- a/data/110/895/953/9/1108959539.geojson
+++ b/data/110/895/953/9/1108959539.geojson
@@ -102,7 +102,13 @@
         }
     ],
     "wof:id":1108959539,
-    "wof:lastmodified":1566644794,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054572,
     "wof:name":"Komen",
     "wof:parent_id":1108959951,
     "wof:placetype":"localadmin",

--- a/data/110/895/954/1/1108959541.geojson
+++ b/data/110/895/954/1/1108959541.geojson
@@ -141,7 +141,13 @@
         }
     ],
     "wof:id":1108959541,
-    "wof:lastmodified":1566644793,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054571,
     "wof:name":"Bovec",
     "wof:parent_id":1108959947,
     "wof:placetype":"localadmin",

--- a/data/110/895/954/5/1108959545.geojson
+++ b/data/110/895/954/5/1108959545.geojson
@@ -105,7 +105,13 @@
         }
     ],
     "wof:id":1108959545,
-    "wof:lastmodified":1566644793,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054571,
     "wof:name":"Ajdov\u0161\u010dina",
     "wof:parent_id":1108959947,
     "wof:placetype":"localadmin",

--- a/data/110/895/954/7/1108959547.geojson
+++ b/data/110/895/954/7/1108959547.geojson
@@ -72,7 +72,13 @@
         }
     ],
     "wof:id":1108959547,
-    "wof:lastmodified":1566644792,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054571,
     "wof:name":"Gornji Grad",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/954/9/1108959549.geojson
+++ b/data/110/895/954/9/1108959549.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959549,
-    "wof:lastmodified":1566644792,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054571,
     "wof:name":"Hrpelje-Kozina",
     "wof:parent_id":1108959951,
     "wof:placetype":"localadmin",

--- a/data/110/895/955/1/1108959551.geojson
+++ b/data/110/895/955/1/1108959551.geojson
@@ -165,7 +165,13 @@
         }
     ],
     "wof:id":1108959551,
-    "wof:lastmodified":1566644813,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054578,
     "wof:name":"Izola",
     "wof:parent_id":1108959951,
     "wof:placetype":"localadmin",

--- a/data/110/895/955/3/1108959553.geojson
+++ b/data/110/895/955/3/1108959553.geojson
@@ -72,7 +72,13 @@
         }
     ],
     "wof:id":1108959553,
-    "wof:lastmodified":1566644814,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054578,
     "wof:name":"Pesnica",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/955/5/1108959555.geojson
+++ b/data/110/895/955/5/1108959555.geojson
@@ -108,7 +108,13 @@
         }
     ],
     "wof:id":1108959555,
-    "wof:lastmodified":1566644814,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054578,
     "wof:name":"Podvelka",
     "wof:parent_id":1108959955,
     "wof:placetype":"localadmin",

--- a/data/110/895/955/7/1108959557.geojson
+++ b/data/110/895/955/7/1108959557.geojson
@@ -72,7 +72,13 @@
         }
     ],
     "wof:id":1108959557,
-    "wof:lastmodified":1566644813,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054578,
     "wof:name":"Radlje ob Dravi",
     "wof:parent_id":1108959955,
     "wof:placetype":"localadmin",

--- a/data/110/895/955/9/1108959559.geojson
+++ b/data/110/895/955/9/1108959559.geojson
@@ -153,7 +153,13 @@
         }
     ],
     "wof:id":1108959559,
-    "wof:lastmodified":1566644813,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054578,
     "wof:name":"Postojna",
     "wof:parent_id":1108959953,
     "wof:placetype":"localadmin",

--- a/data/110/895/956/3/1108959563.geojson
+++ b/data/110/895/956/3/1108959563.geojson
@@ -72,7 +72,13 @@
         }
     ],
     "wof:id":1108959563,
-    "wof:lastmodified":1566644867,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054595,
     "wof:name":"Osilnica",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/956/5/1108959565.geojson
+++ b/data/110/895/956/5/1108959565.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959565,
-    "wof:lastmodified":1566644867,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054595,
     "wof:name":"\u0160entilj",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/956/7/1108959567.geojson
+++ b/data/110/895/956/7/1108959567.geojson
@@ -105,7 +105,13 @@
         }
     ],
     "wof:id":1108959567,
-    "wof:lastmodified":1566644866,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054595,
     "wof:name":"\u0160alovci",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/956/9/1108959569.geojson
+++ b/data/110/895/956/9/1108959569.geojson
@@ -81,7 +81,13 @@
         }
     ],
     "wof:id":1108959569,
-    "wof:lastmodified":1566644866,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054595,
     "wof:name":"Radenci",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/957/1/1108959571.geojson
+++ b/data/110/895/957/1/1108959571.geojson
@@ -123,7 +123,13 @@
         }
     ],
     "wof:id":1108959571,
-    "wof:lastmodified":1566644839,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054586,
     "wof:name":"Hrastnik",
     "wof:parent_id":1108959963,
     "wof:placetype":"localadmin",

--- a/data/110/895/957/3/1108959573.geojson
+++ b/data/110/895/957/3/1108959573.geojson
@@ -81,7 +81,13 @@
         }
     ],
     "wof:id":1108959573,
-    "wof:lastmodified":1566644839,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054586,
     "wof:name":"\u010crna na Koro\u0161kem",
     "wof:parent_id":1108959955,
     "wof:placetype":"localadmin",

--- a/data/110/895/957/5/1108959575.geojson
+++ b/data/110/895/957/5/1108959575.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959575,
-    "wof:lastmodified":1566644839,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054586,
     "wof:name":"Dobrepolje",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/957/7/1108959577.geojson
+++ b/data/110/895/957/7/1108959577.geojson
@@ -108,7 +108,13 @@
         }
     ],
     "wof:id":1108959577,
-    "wof:lastmodified":1566644838,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054585,
     "wof:name":"Cerkno",
     "wof:parent_id":1108959947,
     "wof:placetype":"localadmin",

--- a/data/110/895/958/1/1108959581.geojson
+++ b/data/110/895/958/1/1108959581.geojson
@@ -102,7 +102,13 @@
         }
     ],
     "wof:id":1108959581,
-    "wof:lastmodified":1566644854,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054591,
     "wof:name":"Kozje",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/958/3/1108959583.geojson
+++ b/data/110/895/958/3/1108959583.geojson
@@ -108,7 +108,13 @@
         }
     ],
     "wof:id":1108959583,
-    "wof:lastmodified":1566644855,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054591,
     "wof:name":"Ivan\u010dna Gorica",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/958/5/1108959585.geojson
+++ b/data/110/895/958/5/1108959585.geojson
@@ -144,7 +144,13 @@
         }
     ],
     "wof:id":1108959585,
-    "wof:lastmodified":1566644856,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054591,
     "wof:name":"Bre\u017eice",
     "wof:parent_id":1108959965,
     "wof:placetype":"localadmin",

--- a/data/110/895/958/7/1108959587.geojson
+++ b/data/110/895/958/7/1108959587.geojson
@@ -84,7 +84,13 @@
         }
     ],
     "wof:id":1108959587,
-    "wof:lastmodified":1566644854,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054591,
     "wof:name":"Pivka",
     "wof:parent_id":1108959953,
     "wof:placetype":"localadmin",

--- a/data/110/895/958/9/1108959589.geojson
+++ b/data/110/895/958/9/1108959589.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959589,
-    "wof:lastmodified":1566644854,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054591,
     "wof:name":"Ra\u010de-Fram",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/959/1/1108959591.geojson
+++ b/data/110/895/959/1/1108959591.geojson
@@ -99,7 +99,13 @@
         }
     ],
     "wof:id":1108959591,
-    "wof:lastmodified":1566644850,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054589,
     "wof:name":"Sveti Jurij ob \u0160\u010davnici",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/959/3/1108959593.geojson
+++ b/data/110/895/959/3/1108959593.geojson
@@ -180,7 +180,13 @@
         }
     ],
     "wof:id":1108959593,
-    "wof:lastmodified":1566644850,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054590,
     "wof:name":"Velenje",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/959/5/1108959595.geojson
+++ b/data/110/895/959/5/1108959595.geojson
@@ -114,7 +114,13 @@
         }
     ],
     "wof:id":1108959595,
-    "wof:lastmodified":1566644850,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054590,
     "wof:name":"Odranci",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/959/9/1108959599.geojson
+++ b/data/110/895/959/9/1108959599.geojson
@@ -99,7 +99,13 @@
         }
     ],
     "wof:id":1108959599,
-    "wof:lastmodified":1566644850,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054589,
     "wof:name":"Ribnica",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/960/1/1108959601.geojson
+++ b/data/110/895/960/1/1108959601.geojson
@@ -78,7 +78,13 @@
         }
     ],
     "wof:id":1108959601,
-    "wof:lastmodified":1566644857,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054592,
     "wof:name":"Semi\u010d",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/960/3/1108959603.geojson
+++ b/data/110/895/960/3/1108959603.geojson
@@ -84,7 +84,13 @@
         }
     ],
     "wof:id":1108959603,
-    "wof:lastmodified":1566644858,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054592,
     "wof:name":"Turni\u0161\u010de",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/960/5/1108959605.geojson
+++ b/data/110/895/960/5/1108959605.geojson
@@ -75,7 +75,13 @@
         }
     ],
     "wof:id":1108959605,
-    "wof:lastmodified":1566644858,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054592,
     "wof:name":"\u0160kocjan",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/960/7/1108959607.geojson
+++ b/data/110/895/960/7/1108959607.geojson
@@ -105,7 +105,13 @@
         }
     ],
     "wof:id":1108959607,
-    "wof:lastmodified":1566644857,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054592,
     "wof:name":"\u0160marje pri Jel\u0161ah",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/960/9/1108959609.geojson
+++ b/data/110/895/960/9/1108959609.geojson
@@ -75,7 +75,13 @@
         }
     ],
     "wof:id":1108959609,
-    "wof:lastmodified":1566644857,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054592,
     "wof:name":"Rogatec",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/961/1/1108959611.geojson
+++ b/data/110/895/961/1/1108959611.geojson
@@ -114,7 +114,13 @@
         }
     ],
     "wof:id":1108959611,
-    "wof:lastmodified":1566644846,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054588,
     "wof:name":"Ru\u0161e",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/961/3/1108959613.geojson
+++ b/data/110/895/961/3/1108959613.geojson
@@ -198,7 +198,13 @@
         }
     ],
     "wof:id":1108959613,
-    "wof:lastmodified":1566644846,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054588,
     "wof:name":"Piran",
     "wof:parent_id":1108959951,
     "wof:placetype":"localadmin",

--- a/data/110/895/961/7/1108959617.geojson
+++ b/data/110/895/961/7/1108959617.geojson
@@ -87,7 +87,13 @@
         }
     ],
     "wof:id":1108959617,
-    "wof:lastmodified":1566644846,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054588,
     "wof:name":"Tolmin",
     "wof:parent_id":1108959947,
     "wof:placetype":"localadmin",

--- a/data/110/895/961/9/1108959619.geojson
+++ b/data/110/895/961/9/1108959619.geojson
@@ -66,7 +66,13 @@
         }
     ],
     "wof:id":1108959619,
-    "wof:lastmodified":1566644845,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054588,
     "wof:name":"Zavr\u010d",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/962/1/1108959621.geojson
+++ b/data/110/895/962/1/1108959621.geojson
@@ -84,7 +84,13 @@
         }
     ],
     "wof:id":1108959621,
-    "wof:lastmodified":1566644805,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054575,
     "wof:name":"Dobrna",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/962/3/1108959623.geojson
+++ b/data/110/895/962/3/1108959623.geojson
@@ -66,7 +66,13 @@
         }
     ],
     "wof:id":1108959623,
-    "wof:lastmodified":1566644805,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054575,
     "wof:name":"Vipava",
     "wof:parent_id":1108959947,
     "wof:placetype":"localadmin",

--- a/data/110/895/962/5/1108959625.geojson
+++ b/data/110/895/962/5/1108959625.geojson
@@ -75,7 +75,13 @@
         }
     ],
     "wof:id":1108959625,
-    "wof:lastmodified":1566644805,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054575,
     "wof:name":"Jezersko",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/962/7/1108959627.geojson
+++ b/data/110/895/962/7/1108959627.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959627,
-    "wof:lastmodified":1566644805,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054575,
     "wof:name":"Sveti Andra\u017e v Slov. goricah",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/962/9/1108959629.geojson
+++ b/data/110/895/962/9/1108959629.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959629,
-    "wof:lastmodified":1566644804,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054575,
     "wof:name":"\u0160empeter-Vrtojba",
     "wof:parent_id":1108959947,
     "wof:placetype":"localadmin",

--- a/data/110/895/963/1/1108959631.geojson
+++ b/data/110/895/963/1/1108959631.geojson
@@ -108,7 +108,13 @@
         }
     ],
     "wof:id":1108959631,
-    "wof:lastmodified":1566644806,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054576,
     "wof:name":"\u0160tore",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/963/5/1108959635.geojson
+++ b/data/110/895/963/5/1108959635.geojson
@@ -111,7 +111,13 @@
         }
     ],
     "wof:id":1108959635,
-    "wof:lastmodified":1566644807,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054576,
     "wof:name":"Polzela",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/963/7/1108959637.geojson
+++ b/data/110/895/963/7/1108959637.geojson
@@ -108,7 +108,13 @@
         }
     ],
     "wof:id":1108959637,
-    "wof:lastmodified":1566644806,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054575,
     "wof:name":"Hodo\u0161",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/963/9/1108959639.geojson
+++ b/data/110/895/963/9/1108959639.geojson
@@ -102,7 +102,13 @@
         }
     ],
     "wof:id":1108959639,
-    "wof:lastmodified":1566644806,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054575,
     "wof:name":"Sol\u010dava",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/964/1/1108959641.geojson
+++ b/data/110/895/964/1/1108959641.geojson
@@ -138,7 +138,13 @@
         }
     ],
     "wof:id":1108959641,
-    "wof:lastmodified":1566644810,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054577,
     "wof:name":"Slovenska Bistrica",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/964/3/1108959643.geojson
+++ b/data/110/895/964/3/1108959643.geojson
@@ -132,7 +132,13 @@
         }
     ],
     "wof:id":1108959643,
-    "wof:lastmodified":1566644810,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054577,
     "wof:name":"Ravne na Koro\u0161kem",
     "wof:parent_id":1108959955,
     "wof:placetype":"localadmin",

--- a/data/110/895/964/5/1108959645.geojson
+++ b/data/110/895/964/5/1108959645.geojson
@@ -174,7 +174,13 @@
         }
     ],
     "wof:id":1108959645,
-    "wof:lastmodified":1566644811,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054577,
     "wof:name":"Slovenj Gradec",
     "wof:parent_id":1108959955,
     "wof:placetype":"localadmin",

--- a/data/110/895/964/7/1108959647.geojson
+++ b/data/110/895/964/7/1108959647.geojson
@@ -75,7 +75,13 @@
         }
     ],
     "wof:id":1108959647,
-    "wof:lastmodified":1566644809,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054577,
     "wof:name":"\u0160en\u010dur",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/964/9/1108959649.geojson
+++ b/data/110/895/964/9/1108959649.geojson
@@ -108,7 +108,13 @@
         }
     ],
     "wof:id":1108959649,
-    "wof:lastmodified":1566644809,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054576,
     "wof:name":"Pod\u010detrtek",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/965/3/1108959653.geojson
+++ b/data/110/895/965/3/1108959653.geojson
@@ -69,7 +69,13 @@
         }
     ],
     "wof:id":1108959653,
-    "wof:lastmodified":1566644796,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054572,
     "wof:name":"Vojnik",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/965/5/1108959655.geojson
+++ b/data/110/895/965/5/1108959655.geojson
@@ -108,7 +108,13 @@
         }
     ],
     "wof:id":1108959655,
-    "wof:lastmodified":1566644797,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054573,
     "wof:name":"Roga\u0161ovci",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/965/7/1108959657.geojson
+++ b/data/110/895/965/7/1108959657.geojson
@@ -78,7 +78,13 @@
         }
     ],
     "wof:id":1108959657,
-    "wof:lastmodified":1566644796,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054572,
     "wof:name":"Preddvor",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/965/9/1108959659.geojson
+++ b/data/110/895/965/9/1108959659.geojson
@@ -201,7 +201,13 @@
         }
     ],
     "wof:id":1108959659,
-    "wof:lastmodified":1566644796,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054572,
     "wof:name":"Ptuj",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/966/1/1108959661.geojson
+++ b/data/110/895/966/1/1108959661.geojson
@@ -105,7 +105,13 @@
         }
     ],
     "wof:id":1108959661,
-    "wof:lastmodified":1566644847,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054588,
     "wof:name":"Selnica ob Dravi",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/966/3/1108959663.geojson
+++ b/data/110/895/966/3/1108959663.geojson
@@ -135,7 +135,13 @@
         }
     ],
     "wof:id":1108959663,
-    "wof:lastmodified":1566644847,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054589,
     "wof:name":"Grad",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/966/5/1108959665.geojson
+++ b/data/110/895/966/5/1108959665.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959665,
-    "wof:lastmodified":1566644847,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054589,
     "wof:name":"Miklav\u017e na Dravskem polju",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/966/7/1108959667.geojson
+++ b/data/110/895/966/7/1108959667.geojson
@@ -111,7 +111,13 @@
         }
     ],
     "wof:id":1108959667,
-    "wof:lastmodified":1566644847,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054588,
     "wof:name":"Apa\u010de",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/967/1/1108959671.geojson
+++ b/data/110/895/967/1/1108959671.geojson
@@ -75,7 +75,13 @@
         }
     ],
     "wof:id":1108959671,
-    "wof:lastmodified":1566644853,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054590,
     "wof:name":"Zre\u010de",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/967/3/1108959673.geojson
+++ b/data/110/895/967/3/1108959673.geojson
@@ -78,7 +78,13 @@
         }
     ],
     "wof:id":1108959673,
-    "wof:lastmodified":1566644853,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054591,
     "wof:name":"\u017diri",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/967/5/1108959675.geojson
+++ b/data/110/895/967/5/1108959675.geojson
@@ -78,7 +78,13 @@
         }
     ],
     "wof:id":1108959675,
-    "wof:lastmodified":1566644853,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054591,
     "wof:name":"Dolenjske Toplice",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/967/7/1108959677.geojson
+++ b/data/110/895/967/7/1108959677.geojson
@@ -111,7 +111,13 @@
         }
     ],
     "wof:id":1108959677,
-    "wof:lastmodified":1566644853,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054590,
     "wof:name":"Vuzenica",
     "wof:parent_id":1108959955,
     "wof:placetype":"localadmin",

--- a/data/110/895/967/9/1108959679.geojson
+++ b/data/110/895/967/9/1108959679.geojson
@@ -72,7 +72,13 @@
         }
     ],
     "wof:id":1108959679,
-    "wof:lastmodified":1566644852,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054590,
     "wof:name":"Lovrenc na Pohorju",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/968/1/1108959681.geojson
+++ b/data/110/895/968/1/1108959681.geojson
@@ -99,7 +99,13 @@
         }
     ],
     "wof:id":1108959681,
-    "wof:lastmodified":1566644840,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054586,
     "wof:name":"Vitanje",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/968/3/1108959683.geojson
+++ b/data/110/895/968/3/1108959683.geojson
@@ -135,7 +135,13 @@
         }
     ],
     "wof:id":1108959683,
-    "wof:lastmodified":1566644840,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054586,
     "wof:name":"Zagorje ob Savi",
     "wof:parent_id":1108959963,
     "wof:placetype":"localadmin",

--- a/data/110/895/968/5/1108959685.geojson
+++ b/data/110/895/968/5/1108959685.geojson
@@ -66,7 +66,13 @@
         }
     ],
     "wof:id":1108959685,
-    "wof:lastmodified":1566644841,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054586,
     "wof:name":"Dobje",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/968/9/1108959689.geojson
+++ b/data/110/895/968/9/1108959689.geojson
@@ -96,7 +96,13 @@
         }
     ],
     "wof:id":1108959689,
-    "wof:lastmodified":1566644840,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054586,
     "wof:name":"Trzin",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/969/1/1108959691.geojson
+++ b/data/110/895/969/1/1108959691.geojson
@@ -102,7 +102,13 @@
         }
     ],
     "wof:id":1108959691,
-    "wof:lastmodified":1566644868,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054596,
     "wof:name":"Dobrovnik",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/969/3/1108959693.geojson
+++ b/data/110/895/969/3/1108959693.geojson
@@ -219,7 +219,13 @@
         }
     ],
     "wof:id":1108959693,
-    "wof:lastmodified":1566644868,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054596,
     "wof:name":"Celje",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/969/5/1108959695.geojson
+++ b/data/110/895/969/5/1108959695.geojson
@@ -126,7 +126,13 @@
         }
     ],
     "wof:id":1108959695,
-    "wof:lastmodified":1566644869,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054596,
     "wof:name":"Prevalje",
     "wof:parent_id":1108959955,
     "wof:placetype":"localadmin",

--- a/data/110/895/969/7/1108959697.geojson
+++ b/data/110/895/969/7/1108959697.geojson
@@ -108,7 +108,13 @@
         }
     ],
     "wof:id":1108959697,
-    "wof:lastmodified":1566644868,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054596,
     "wof:name":"Velika Polana",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/969/9/1108959699.geojson
+++ b/data/110/895/969/9/1108959699.geojson
@@ -123,7 +123,13 @@
         }
     ],
     "wof:id":1108959699,
-    "wof:lastmodified":1566644867,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054596,
     "wof:name":"\u010crnomelj",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/970/1/1108959701.geojson
+++ b/data/110/895/970/1/1108959701.geojson
@@ -75,7 +75,13 @@
         }
     ],
     "wof:id":1108959701,
-    "wof:lastmodified":1566644821,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054580,
     "wof:name":"\u017delezniki",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/970/3/1108959703.geojson
+++ b/data/110/895/970/3/1108959703.geojson
@@ -99,7 +99,13 @@
         }
     ],
     "wof:id":1108959703,
-    "wof:lastmodified":1566644822,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054580,
     "wof:name":"Cerkvenjak",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/970/7/1108959707.geojson
+++ b/data/110/895/970/7/1108959707.geojson
@@ -114,7 +114,13 @@
         }
     ],
     "wof:id":1108959707,
-    "wof:lastmodified":1566644821,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054580,
     "wof:name":"Cankova",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/970/9/1108959709.geojson
+++ b/data/110/895/970/9/1108959709.geojson
@@ -72,7 +72,13 @@
         }
     ],
     "wof:id":1108959709,
-    "wof:lastmodified":1566644821,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054580,
     "wof:name":"Sveta Ana",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/971/1/1108959711.geojson
+++ b/data/110/895/971/1/1108959711.geojson
@@ -81,7 +81,13 @@
         }
     ],
     "wof:id":1108959711,
-    "wof:lastmodified":1566644829,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054583,
     "wof:name":"Kostel",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/971/3/1108959713.geojson
+++ b/data/110/895/971/3/1108959713.geojson
@@ -78,7 +78,13 @@
         }
     ],
     "wof:id":1108959713,
-    "wof:lastmodified":1566644829,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054583,
     "wof:name":"Prebold",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/971/5/1108959715.geojson
+++ b/data/110/895/971/5/1108959715.geojson
@@ -129,7 +129,13 @@
         }
     ],
     "wof:id":1108959715,
-    "wof:lastmodified":1566644830,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054583,
     "wof:name":"Tabor",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/971/7/1108959717.geojson
+++ b/data/110/895/971/7/1108959717.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959717,
-    "wof:lastmodified":1566644829,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054583,
     "wof:name":"Trnovska vas",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/971/9/1108959719.geojson
+++ b/data/110/895/971/9/1108959719.geojson
@@ -75,7 +75,13 @@
         }
     ],
     "wof:id":1108959719,
-    "wof:lastmodified":1566644829,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054582,
     "wof:name":"Gori\u0161nica",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/972/1/1108959721.geojson
+++ b/data/110/895/972/1/1108959721.geojson
@@ -105,7 +105,13 @@
         }
     ],
     "wof:id":1108959721,
-    "wof:lastmodified":1566644881,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054601,
     "wof:name":"Polj\u010dane",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/972/5/1108959725.geojson
+++ b/data/110/895/972/5/1108959725.geojson
@@ -102,7 +102,13 @@
         }
     ],
     "wof:id":1108959725,
-    "wof:lastmodified":1566644881,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054601,
     "wof:name":"Sredi\u0161\u010de ob Dravi",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/972/7/1108959727.geojson
+++ b/data/110/895/972/7/1108959727.geojson
@@ -69,7 +69,13 @@
         }
     ],
     "wof:id":1108959727,
-    "wof:lastmodified":1566644881,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054601,
     "wof:name":"Muta",
     "wof:parent_id":1108959955,
     "wof:placetype":"localadmin",

--- a/data/110/895/972/9/1108959729.geojson
+++ b/data/110/895/972/9/1108959729.geojson
@@ -108,7 +108,13 @@
         }
     ],
     "wof:id":1108959729,
-    "wof:lastmodified":1566644880,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054601,
     "wof:name":"\u0160martno ob Paki",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/973/1/1108959731.geojson
+++ b/data/110/895/973/1/1108959731.geojson
@@ -84,7 +84,13 @@
         }
     ],
     "wof:id":1108959731,
-    "wof:lastmodified":1566644871,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054597,
     "wof:name":"\u0160o\u0161tanj",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/973/3/1108959733.geojson
+++ b/data/110/895/973/3/1108959733.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959733,
-    "wof:lastmodified":1566644872,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054597,
     "wof:name":"Ren\u010de-Vogrsko",
     "wof:parent_id":1108959947,
     "wof:placetype":"localadmin",

--- a/data/110/895/973/5/1108959735.geojson
+++ b/data/110/895/973/5/1108959735.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959735,
-    "wof:lastmodified":1566644872,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054598,
     "wof:name":"Gorje",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/973/7/1108959737.geojson
+++ b/data/110/895/973/7/1108959737.geojson
@@ -108,7 +108,13 @@
         }
     ],
     "wof:id":1108959737,
-    "wof:lastmodified":1566644871,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054597,
     "wof:name":"Oplotnica",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/973/9/1108959739.geojson
+++ b/data/110/895/973/9/1108959739.geojson
@@ -75,7 +75,13 @@
         }
     ],
     "wof:id":1108959739,
-    "wof:lastmodified":1566644871,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054597,
     "wof:name":"Kidri\u010devo",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/974/3/1108959743.geojson
+++ b/data/110/895/974/3/1108959743.geojson
@@ -99,7 +99,13 @@
         }
     ],
     "wof:id":1108959743,
-    "wof:lastmodified":1566644873,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054598,
     "wof:name":"Cirkulane",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/974/5/1108959745.geojson
+++ b/data/110/895/974/5/1108959745.geojson
@@ -96,7 +96,13 @@
         }
     ],
     "wof:id":1108959745,
-    "wof:lastmodified":1566644873,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054598,
     "wof:name":"\u0160martno pri Litiji",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/974/7/1108959747.geojson
+++ b/data/110/895/974/7/1108959747.geojson
@@ -72,7 +72,13 @@
         }
     ],
     "wof:id":1108959747,
-    "wof:lastmodified":1566644872,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054598,
     "wof:name":"Videm",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/974/9/1108959749.geojson
+++ b/data/110/895/974/9/1108959749.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959749,
-    "wof:lastmodified":1566644872,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054598,
     "wof:name":"Ho\u010de-Slivnica",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/975/1/1108959751.geojson
+++ b/data/110/895/975/1/1108959751.geojson
@@ -75,7 +75,13 @@
         }
     ],
     "wof:id":1108959751,
-    "wof:lastmodified":1566644880,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054600,
     "wof:name":"Mirna Pe\u010d",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/975/3/1108959753.geojson
+++ b/data/110/895/975/3/1108959753.geojson
@@ -132,7 +132,13 @@
         }
     ],
     "wof:id":1108959753,
-    "wof:lastmodified":1566644880,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054600,
     "wof:name":"Slovenske Konjice",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/975/5/1108959755.geojson
+++ b/data/110/895/975/5/1108959755.geojson
@@ -75,7 +75,13 @@
         }
     ],
     "wof:id":1108959755,
-    "wof:lastmodified":1566644880,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054600,
     "wof:name":"Destrnik",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/975/7/1108959757.geojson
+++ b/data/110/895/975/7/1108959757.geojson
@@ -108,7 +108,13 @@
         }
     ],
     "wof:id":1108959757,
-    "wof:lastmodified":1566644879,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054600,
     "wof:name":"Podlehnik",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/976/1/1108959761.geojson
+++ b/data/110/895/976/1/1108959761.geojson
@@ -78,7 +78,13 @@
         }
     ],
     "wof:id":1108959761,
-    "wof:lastmodified":1566644836,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054585,
     "wof:name":"Dornava",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/976/3/1108959763.geojson
+++ b/data/110/895/976/3/1108959763.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959763,
-    "wof:lastmodified":1566644836,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054585,
     "wof:name":"Hajdina",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/976/5/1108959765.geojson
+++ b/data/110/895/976/5/1108959765.geojson
@@ -96,7 +96,13 @@
         }
     ],
     "wof:id":1108959765,
-    "wof:lastmodified":1566644836,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054585,
     "wof:name":"Ormo\u017e",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/976/7/1108959767.geojson
+++ b/data/110/895/976/7/1108959767.geojson
@@ -72,7 +72,13 @@
         }
     ],
     "wof:id":1108959767,
-    "wof:lastmodified":1566644836,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054585,
     "wof:name":"\u017detale",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/976/9/1108959769.geojson
+++ b/data/110/895/976/9/1108959769.geojson
@@ -105,7 +105,13 @@
         }
     ],
     "wof:id":1108959769,
-    "wof:lastmodified":1566644835,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054584,
     "wof:name":"Ribnica na Pohorju",
     "wof:parent_id":1108959955,
     "wof:placetype":"localadmin",

--- a/data/110/895/977/1/1108959771.geojson
+++ b/data/110/895/977/1/1108959771.geojson
@@ -81,7 +81,13 @@
         }
     ],
     "wof:id":1108959771,
-    "wof:lastmodified":1566644817,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054579,
     "wof:name":"Ver\u017eej",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/977/3/1108959773.geojson
+++ b/data/110/895/977/3/1108959773.geojson
@@ -102,7 +102,13 @@
         }
     ],
     "wof:id":1108959773,
-    "wof:lastmodified":1566644817,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054579,
     "wof:name":"Makole",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/977/5/1108959775.geojson
+++ b/data/110/895/977/5/1108959775.geojson
@@ -90,7 +90,13 @@
         }
     ],
     "wof:id":1108959775,
-    "wof:lastmodified":1566644817,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054579,
     "wof:name":"Kri\u017eevci",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/977/9/1108959779.geojson
+++ b/data/110/895/977/9/1108959779.geojson
@@ -105,7 +105,13 @@
         }
     ],
     "wof:id":1108959779,
-    "wof:lastmodified":1566644817,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054579,
     "wof:name":"Markovci",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/978/1/1108959781.geojson
+++ b/data/110/895/978/1/1108959781.geojson
@@ -108,7 +108,13 @@
         }
     ],
     "wof:id":1108959781,
-    "wof:lastmodified":1566644826,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054582,
     "wof:name":"Jur\u0161inci",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/978/3/1108959783.geojson
+++ b/data/110/895/978/3/1108959783.geojson
@@ -105,7 +105,13 @@
         }
     ],
     "wof:id":1108959783,
-    "wof:lastmodified":1566644826,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054582,
     "wof:name":"Star\u0161e",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/978/5/1108959785.geojson
+++ b/data/110/895/978/5/1108959785.geojson
@@ -267,7 +267,13 @@
         }
     ],
     "wof:id":1108959785,
-    "wof:lastmodified":1566644827,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054582,
     "wof:name":"Maribor",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/978/7/1108959787.geojson
+++ b/data/110/895/978/7/1108959787.geojson
@@ -117,7 +117,13 @@
         }
     ],
     "wof:id":1108959787,
-    "wof:lastmodified":1566644826,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054581,
     "wof:name":"\u017du\u017eemberk",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/978/9/1108959789.geojson
+++ b/data/110/895/978/9/1108959789.geojson
@@ -138,7 +138,13 @@
         }
     ],
     "wof:id":1108959789,
-    "wof:lastmodified":1566644825,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054581,
     "wof:name":"Se\u017eana",
     "wof:parent_id":1108959951,
     "wof:placetype":"localadmin",

--- a/data/110/895/979/1/1108959791.geojson
+++ b/data/110/895/979/1/1108959791.geojson
@@ -108,7 +108,13 @@
         }
     ],
     "wof:id":1108959791,
-    "wof:lastmodified":1566644823,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054581,
     "wof:name":"\u0160entjur",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/979/3/1108959793.geojson
+++ b/data/110/895/979/3/1108959793.geojson
@@ -87,7 +87,13 @@
         }
     ],
     "wof:id":1108959793,
-    "wof:lastmodified":1566644823,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054581,
     "wof:name":"Stra\u017ea",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/979/7/1108959797.geojson
+++ b/data/110/895/979/7/1108959797.geojson
@@ -177,7 +177,13 @@
         }
     ],
     "wof:id":1108959797,
-    "wof:lastmodified":1566644823,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054580,
     "wof:name":"Bled",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/979/9/1108959799.geojson
+++ b/data/110/895/979/9/1108959799.geojson
@@ -150,7 +150,13 @@
         }
     ],
     "wof:id":1108959799,
-    "wof:lastmodified":1566644822,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054580,
     "wof:name":"Dom\u017eale",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/980/1/1108959801.geojson
+++ b/data/110/895/980/1/1108959801.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959801,
-    "wof:lastmodified":1566644874,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054598,
     "wof:name":"Sveta Trojica v Slovenskih goricah",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/980/3/1108959803.geojson
+++ b/data/110/895/980/3/1108959803.geojson
@@ -102,7 +102,13 @@
         }
     ],
     "wof:id":1108959803,
-    "wof:lastmodified":1566644875,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054598,
     "wof:name":"Roga\u0161ka Slatina",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/980/5/1108959805.geojson
+++ b/data/110/895/980/5/1108959805.geojson
@@ -81,7 +81,13 @@
         }
     ],
     "wof:id":1108959805,
-    "wof:lastmodified":1566644875,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054599,
     "wof:name":"Sodra\u017eica",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/980/7/1108959807.geojson
+++ b/data/110/895/980/7/1108959807.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959807,
-    "wof:lastmodified":1566644874,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054598,
     "wof:name":"Lukovica",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/980/9/1108959809.geojson
+++ b/data/110/895/980/9/1108959809.geojson
@@ -96,7 +96,13 @@
         }
     ],
     "wof:id":1108959809,
-    "wof:lastmodified":1566644874,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054598,
     "wof:name":"Re\u010dica ob Savinji",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/981/1/1108959811.geojson
+++ b/data/110/895/981/1/1108959811.geojson
@@ -93,7 +93,13 @@
         }
     ],
     "wof:id":1108959811,
-    "wof:lastmodified":1566644879,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054600,
     "wof:name":"Brda",
     "wof:parent_id":1108959947,
     "wof:placetype":"localadmin",

--- a/data/110/895/981/5/1108959815.geojson
+++ b/data/110/895/981/5/1108959815.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959815,
-    "wof:lastmodified":1566644879,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054600,
     "wof:name":"Sveti Jurij v Slovenskih goricah",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/981/7/1108959817.geojson
+++ b/data/110/895/981/7/1108959817.geojson
@@ -123,7 +123,13 @@
         }
     ],
     "wof:id":1108959817,
-    "wof:lastmodified":1566644879,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054600,
     "wof:name":"Gornja Radgona",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/981/9/1108959819.geojson
+++ b/data/110/895/981/9/1108959819.geojson
@@ -78,7 +78,13 @@
         }
     ],
     "wof:id":1108959819,
-    "wof:lastmodified":1566644878,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054600,
     "wof:name":"Bohinj",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/982/1/1108959821.geojson
+++ b/data/110/895/982/1/1108959821.geojson
@@ -165,7 +165,13 @@
         }
     ],
     "wof:id":1108959821,
-    "wof:lastmodified":1566644834,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054584,
     "wof:name":"\u0160kofja Loka",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/982/3/1108959823.geojson
+++ b/data/110/895/982/3/1108959823.geojson
@@ -84,7 +84,13 @@
         }
     ],
     "wof:id":1108959823,
-    "wof:lastmodified":1566644835,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054584,
     "wof:name":"\u010cren\u0161ovci",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/982/5/1108959825.geojson
+++ b/data/110/895/982/5/1108959825.geojson
@@ -90,7 +90,13 @@
         }
     ],
     "wof:id":1108959825,
-    "wof:lastmodified":1566644835,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054584,
     "wof:name":"Radovljica",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/982/7/1108959827.geojson
+++ b/data/110/895/982/7/1108959827.geojson
@@ -87,7 +87,13 @@
         }
     ],
     "wof:id":1108959827,
-    "wof:lastmodified":1566644834,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054584,
     "wof:name":"Vransko",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/982/9/1108959829.geojson
+++ b/data/110/895/982/9/1108959829.geojson
@@ -81,7 +81,13 @@
         }
     ],
     "wof:id":1108959829,
-    "wof:lastmodified":1566644834,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054584,
     "wof:name":"Benedikt",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/983/3/1108959833.geojson
+++ b/data/110/895/983/3/1108959833.geojson
@@ -93,7 +93,13 @@
         }
     ],
     "wof:id":1108959833,
-    "wof:lastmodified":1566644818,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054579,
     "wof:name":"\u0160marje\u0161ke Toplice",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/983/5/1108959835.geojson
+++ b/data/110/895/983/5/1108959835.geojson
@@ -108,7 +108,13 @@
         }
     ],
     "wof:id":1108959835,
-    "wof:lastmodified":1566644819,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054579,
     "wof:name":"Kostanjevica na Krki",
     "wof:parent_id":1108959965,
     "wof:placetype":"localadmin",

--- a/data/110/895/983/7/1108959837.geojson
+++ b/data/110/895/983/7/1108959837.geojson
@@ -75,7 +75,13 @@
         }
     ],
     "wof:id":1108959837,
-    "wof:lastmodified":1566644818,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054579,
     "wof:name":"Komenda",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/983/9/1108959839.geojson
+++ b/data/110/895/983/9/1108959839.geojson
@@ -108,7 +108,13 @@
         }
     ],
     "wof:id":1108959839,
-    "wof:lastmodified":1566644818,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054579,
     "wof:name":"Trebnje",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/984/1/1108959841.geojson
+++ b/data/110/895/984/1/1108959841.geojson
@@ -99,7 +99,13 @@
         }
     ],
     "wof:id":1108959841,
-    "wof:lastmodified":1566644819,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054580,
     "wof:name":"\u0160entrupert",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/984/3/1108959843.geojson
+++ b/data/110/895/984/3/1108959843.geojson
@@ -96,7 +96,13 @@
         }
     ],
     "wof:id":1108959843,
-    "wof:lastmodified":1566644820,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054580,
     "wof:name":"Kranjska Gora",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/984/5/1108959845.geojson
+++ b/data/110/895/984/5/1108959845.geojson
@@ -93,7 +93,13 @@
         }
     ],
     "wof:id":1108959845,
-    "wof:lastmodified":1566644820,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054580,
     "wof:name":"Diva\u010da",
     "wof:parent_id":1108959951,
     "wof:placetype":"localadmin",

--- a/data/110/895/984/7/1108959847.geojson
+++ b/data/110/895/984/7/1108959847.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959847,
-    "wof:lastmodified":1566644819,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054579,
     "wof:name":"Dobrova-Polhov Gradec",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/985/1/1108959851.geojson
+++ b/data/110/895/985/1/1108959851.geojson
@@ -123,7 +123,13 @@
         }
     ],
     "wof:id":1108959851,
-    "wof:lastmodified":1566644831,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054583,
     "wof:name":"Vrhnika",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/985/3/1108959853.geojson
+++ b/data/110/895/985/3/1108959853.geojson
@@ -102,7 +102,13 @@
         }
     ],
     "wof:id":1108959853,
-    "wof:lastmodified":1566644831,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054583,
     "wof:name":"Razkri\u017eje",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/985/5/1108959855.geojson
+++ b/data/110/895/985/5/1108959855.geojson
@@ -102,7 +102,13 @@
         }
     ],
     "wof:id":1108959855,
-    "wof:lastmodified":1566644831,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054583,
     "wof:name":"Braslov\u010de",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/985/7/1108959857.geojson
+++ b/data/110/895/985/7/1108959857.geojson
@@ -105,7 +105,13 @@
         }
     ],
     "wof:id":1108959857,
-    "wof:lastmodified":1566644830,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054583,
     "wof:name":"Ankaran",
     "wof:parent_id":1108959951,
     "wof:placetype":"localadmin",

--- a/data/110/895/985/9/1108959859.geojson
+++ b/data/110/895/985/9/1108959859.geojson
@@ -99,7 +99,13 @@
         }
     ],
     "wof:id":1108959859,
-    "wof:lastmodified":1566644830,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054583,
     "wof:name":"Velike La\u0161\u010de",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/986/1/1108959861.geojson
+++ b/data/110/895/986/1/1108959861.geojson
@@ -69,7 +69,13 @@
         }
     ],
     "wof:id":1108959861,
-    "wof:lastmodified":1566644882,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054601,
     "wof:name":"Dol pri Ljubljani",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/986/3/1108959863.geojson
+++ b/data/110/895/986/3/1108959863.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959863,
-    "wof:lastmodified":1566644882,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054601,
     "wof:name":"Lo\u0161ka dolina",
     "wof:parent_id":1108959953,
     "wof:placetype":"localadmin",

--- a/data/110/895/986/5/1108959865.geojson
+++ b/data/110/895/986/5/1108959865.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959865,
-    "wof:lastmodified":1566644882,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054601,
     "wof:name":"Horjul",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/986/9/1108959869.geojson
+++ b/data/110/895/986/9/1108959869.geojson
@@ -84,7 +84,13 @@
         }
     ],
     "wof:id":1108959869,
-    "wof:lastmodified":1566644882,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054601,
     "wof:name":"Mirna",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/987/1/1108959871.geojson
+++ b/data/110/895/987/1/1108959871.geojson
@@ -66,7 +66,13 @@
         }
     ],
     "wof:id":1108959871,
-    "wof:lastmodified":1566644870,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054597,
     "wof:name":"Borovnica",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/987/3/1108959873.geojson
+++ b/data/110/895/987/3/1108959873.geojson
@@ -126,7 +126,13 @@
         }
     ],
     "wof:id":1108959873,
-    "wof:lastmodified":1566644870,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054597,
     "wof:name":"Ilirska Bistrica",
     "wof:parent_id":1108959953,
     "wof:placetype":"localadmin",

--- a/data/110/895/987/5/1108959875.geojson
+++ b/data/110/895/987/5/1108959875.geojson
@@ -147,7 +147,13 @@
         }
     ],
     "wof:id":1108959875,
-    "wof:lastmodified":1566644871,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054597,
     "wof:name":"Jesenice",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/987/7/1108959877.geojson
+++ b/data/110/895/987/7/1108959877.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959877,
-    "wof:lastmodified":1566644870,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054597,
     "wof:name":"Log-Dragomer",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/987/9/1108959879.geojson
+++ b/data/110/895/987/9/1108959879.geojson
@@ -93,7 +93,13 @@
         }
     ],
     "wof:id":1108959879,
-    "wof:lastmodified":1566644870,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054597,
     "wof:name":"La\u0161ko",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/988/1/1108959881.geojson
+++ b/data/110/895/988/1/1108959881.geojson
@@ -126,7 +126,13 @@
         }
     ],
     "wof:id":1108959881,
-    "wof:lastmodified":1566644877,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054600,
     "wof:name":"Medvode",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/988/3/1108959883.geojson
+++ b/data/110/895/988/3/1108959883.geojson
@@ -120,7 +120,13 @@
         }
     ],
     "wof:id":1108959883,
-    "wof:lastmodified":1566644878,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054600,
     "wof:name":"Rade\u010de",
     "wof:parent_id":1108959965,
     "wof:placetype":"localadmin",

--- a/data/110/895/988/7/1108959887.geojson
+++ b/data/110/895/988/7/1108959887.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959887,
-    "wof:lastmodified":1566644877,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054599,
     "wof:name":"Ig",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/988/9/1108959889.geojson
+++ b/data/110/895/988/9/1108959889.geojson
@@ -84,7 +84,13 @@
         }
     ],
     "wof:id":1108959889,
-    "wof:lastmodified":1566644877,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054599,
     "wof:name":"Logatec",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/989/1/1108959891.geojson
+++ b/data/110/895/989/1/1108959891.geojson
@@ -72,7 +72,13 @@
         }
     ],
     "wof:id":1108959891,
-    "wof:lastmodified":1566644876,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054599,
     "wof:name":"\u0160kofljica",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/989/3/1108959893.geojson
+++ b/data/110/895/989/3/1108959893.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959893,
-    "wof:lastmodified":1566644876,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054599,
     "wof:name":"Bloke",
     "wof:parent_id":1108959953,
     "wof:placetype":"localadmin",

--- a/data/110/895/989/5/1108959895.geojson
+++ b/data/110/895/989/5/1108959895.geojson
@@ -102,7 +102,13 @@
         }
     ],
     "wof:id":1108959895,
-    "wof:lastmodified":1566644876,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054599,
     "wof:name":"Brezovica",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/989/7/1108959897.geojson
+++ b/data/110/895/989/7/1108959897.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959897,
-    "wof:lastmodified":1566644875,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054599,
     "wof:name":"Gorenja vas-Poljane",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/989/9/1108959899.geojson
+++ b/data/110/895/989/9/1108959899.geojson
@@ -66,7 +66,13 @@
         }
     ],
     "wof:id":1108959899,
-    "wof:lastmodified":1566644875,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054599,
     "wof:name":"\u017dirovnica",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/990/1/1108959901.geojson
+++ b/data/110/895/990/1/1108959901.geojson
@@ -78,7 +78,13 @@
         }
     ],
     "wof:id":1108959901,
-    "wof:lastmodified":1566644808,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054576,
     "wof:name":"Nazarje",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/990/5/1108959905.geojson
+++ b/data/110/895/990/5/1108959905.geojson
@@ -132,7 +132,13 @@
         }
     ],
     "wof:id":1108959905,
-    "wof:lastmodified":1566644808,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054576,
     "wof:name":"Cerknica",
     "wof:parent_id":1108959953,
     "wof:placetype":"localadmin",

--- a/data/110/895/990/7/1108959907.geojson
+++ b/data/110/895/990/7/1108959907.geojson
@@ -87,7 +87,13 @@
         }
     ],
     "wof:id":1108959907,
-    "wof:lastmodified":1566644808,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054576,
     "wof:name":"Litija",
     "wof:parent_id":1108959963,
     "wof:placetype":"localadmin",

--- a/data/110/895/990/9/1108959909.geojson
+++ b/data/110/895/990/9/1108959909.geojson
@@ -120,7 +120,13 @@
         }
     ],
     "wof:id":1108959909,
-    "wof:lastmodified":1566644807,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054576,
     "wof:name":"Metlika",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/991/1/1108959911.geojson
+++ b/data/110/895/991/1/1108959911.geojson
@@ -153,7 +153,13 @@
         }
     ],
     "wof:id":1108959911,
-    "wof:lastmodified":1566644798,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054573,
     "wof:name":"Trbovlje",
     "wof:parent_id":1108959963,
     "wof:placetype":"localadmin",

--- a/data/110/895/991/3/1108959913.geojson
+++ b/data/110/895/991/3/1108959913.geojson
@@ -48,7 +48,13 @@
         }
     ],
     "wof:id":1108959913,
-    "wof:lastmodified":1566644799,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054573,
     "wof:name":"Mokronog-Trebelno",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/991/5/1108959915.geojson
+++ b/data/110/895/991/5/1108959915.geojson
@@ -102,7 +102,13 @@
         }
     ],
     "wof:id":1108959915,
-    "wof:lastmodified":1566644799,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054573,
     "wof:name":"Bistrica ob Sotli",
     "wof:parent_id":1108959965,
     "wof:placetype":"localadmin",

--- a/data/110/895/991/7/1108959917.geojson
+++ b/data/110/895/991/7/1108959917.geojson
@@ -117,7 +117,13 @@
         }
     ],
     "wof:id":1108959917,
-    "wof:lastmodified":1566644798,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054573,
     "wof:name":"Tr\u017ei\u010d",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/991/9/1108959919.geojson
+++ b/data/110/895/991/9/1108959919.geojson
@@ -99,7 +99,13 @@
         }
     ],
     "wof:id":1108959919,
-    "wof:lastmodified":1566644797,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054573,
     "wof:name":"Ko\u010devje",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/992/3/1108959923.geojson
+++ b/data/110/895/992/3/1108959923.geojson
@@ -105,7 +105,13 @@
         }
     ],
     "wof:id":1108959923,
-    "wof:lastmodified":1566644849,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054589,
     "wof:name":"Vodice",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/992/5/1108959925.geojson
+++ b/data/110/895/992/5/1108959925.geojson
@@ -99,7 +99,13 @@
         }
     ],
     "wof:id":1108959925,
-    "wof:lastmodified":1566644849,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054589,
     "wof:name":"Moravske Toplice",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/992/7/1108959927.geojson
+++ b/data/110/895/992/7/1108959927.geojson
@@ -120,7 +120,13 @@
         }
     ],
     "wof:id":1108959927,
-    "wof:lastmodified":1566644848,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054589,
     "wof:name":"Sevnica",
     "wof:parent_id":1108959965,
     "wof:placetype":"localadmin",

--- a/data/110/895/992/9/1108959929.geojson
+++ b/data/110/895/992/9/1108959929.geojson
@@ -123,7 +123,13 @@
         }
     ],
     "wof:id":1108959929,
-    "wof:lastmodified":1566644848,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054589,
     "wof:name":"\u017dalec",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/993/1/1108959931.geojson
+++ b/data/110/895/993/1/1108959931.geojson
@@ -54,7 +54,13 @@
         }
     ],
     "wof:id":1108959931,
-    "wof:lastmodified":1566644851,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054590,
     "wof:name":"Sveti Toma\u017e",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/993/3/1108959933.geojson
+++ b/data/110/895/993/3/1108959933.geojson
@@ -210,7 +210,13 @@
         }
     ],
     "wof:id":1108959933,
-    "wof:lastmodified":1566644851,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054590,
     "wof:name":"Kranj",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/993/5/1108959935.geojson
+++ b/data/110/895/993/5/1108959935.geojson
@@ -108,7 +108,13 @@
         }
     ],
     "wof:id":1108959935,
-    "wof:lastmodified":1566644852,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054590,
     "wof:name":"Puconci",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/993/7/1108959937.geojson
+++ b/data/110/895/993/7/1108959937.geojson
@@ -108,7 +108,13 @@
         }
     ],
     "wof:id":1108959937,
-    "wof:lastmodified":1566644851,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054590,
     "wof:name":"\u0160entjernej",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/994/1/1108959941.geojson
+++ b/data/110/895/994/1/1108959941.geojson
@@ -159,7 +159,13 @@
         }
     ],
     "wof:id":1108959941,
-    "wof:lastmodified":1566644862,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054593,
     "wof:name":"Kamnik",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/994/3/1108959943.geojson
+++ b/data/110/895/994/3/1108959943.geojson
@@ -72,7 +72,13 @@
         }
     ],
     "wof:id":1108959943,
-    "wof:lastmodified":1566644863,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054594,
     "wof:name":"Jugovzhodna Slovenija",
     "wof:parent_id":85633779,
     "wof:placetype":"region",

--- a/data/110/895/994/5/1108959945.geojson
+++ b/data/110/895/994/5/1108959945.geojson
@@ -72,7 +72,13 @@
         }
     ],
     "wof:id":1108959945,
-    "wof:lastmodified":1566644865,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054595,
     "wof:name":"Pomurska",
     "wof:parent_id":85633779,
     "wof:placetype":"region",

--- a/data/110/895/994/7/1108959947.geojson
+++ b/data/110/895/994/7/1108959947.geojson
@@ -96,7 +96,13 @@
         }
     ],
     "wof:id":1108959947,
-    "wof:lastmodified":1566644861,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054593,
     "wof:name":"Gori\u0161ka",
     "wof:parent_id":85633779,
     "wof:placetype":"region",

--- a/data/110/895/994/9/1108959949.geojson
+++ b/data/110/895/994/9/1108959949.geojson
@@ -72,7 +72,13 @@
         }
     ],
     "wof:id":1108959949,
-    "wof:lastmodified":1566644859,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054592,
     "wof:name":"Osrednjeslovenska",
     "wof:parent_id":85633779,
     "wof:placetype":"region",

--- a/data/110/895/995/1/1108959951.geojson
+++ b/data/110/895/995/1/1108959951.geojson
@@ -72,7 +72,13 @@
         }
     ],
     "wof:id":1108959951,
-    "wof:lastmodified":1566644843,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054587,
     "wof:name":"Obalno-kra\u0161ka",
     "wof:parent_id":85633779,
     "wof:placetype":"region",

--- a/data/110/895/995/3/1108959953.geojson
+++ b/data/110/895/995/3/1108959953.geojson
@@ -72,7 +72,13 @@
         }
     ],
     "wof:id":1108959953,
-    "wof:lastmodified":1566644844,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054587,
     "wof:name":"Primorsko-notranjska",
     "wof:parent_id":85633779,
     "wof:placetype":"region",

--- a/data/110/895/995/5/1108959955.geojson
+++ b/data/110/895/995/5/1108959955.geojson
@@ -57,7 +57,13 @@
         }
     ],
     "wof:id":1108959955,
-    "wof:lastmodified":1566644845,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054588,
     "wof:name":"Koro\u0161ka",
     "wof:parent_id":85633779,
     "wof:placetype":"region",

--- a/data/110/895/995/9/1108959959.geojson
+++ b/data/110/895/995/9/1108959959.geojson
@@ -72,7 +72,13 @@
         }
     ],
     "wof:id":1108959959,
-    "wof:lastmodified":1566644842,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054586,
     "wof:name":"Savinjska",
     "wof:parent_id":85633779,
     "wof:placetype":"region",

--- a/data/110/895/996/1/1108959961.geojson
+++ b/data/110/895/996/1/1108959961.geojson
@@ -72,7 +72,13 @@
         }
     ],
     "wof:id":1108959961,
-    "wof:lastmodified":1566644801,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054574,
     "wof:name":"Podravska",
     "wof:parent_id":85633779,
     "wof:placetype":"region",

--- a/data/110/895/996/3/1108959963.geojson
+++ b/data/110/895/996/3/1108959963.geojson
@@ -72,7 +72,13 @@
         }
     ],
     "wof:id":1108959963,
-    "wof:lastmodified":1566644802,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054574,
     "wof:name":"Zasavska",
     "wof:parent_id":85633779,
     "wof:placetype":"region",

--- a/data/110/895/996/5/1108959965.geojson
+++ b/data/110/895/996/5/1108959965.geojson
@@ -72,7 +72,13 @@
         }
     ],
     "wof:id":1108959965,
-    "wof:lastmodified":1566644804,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054575,
     "wof:name":"Posavska",
     "wof:parent_id":85633779,
     "wof:placetype":"region",

--- a/data/110/895/996/7/1108959967.geojson
+++ b/data/110/895/996/7/1108959967.geojson
@@ -72,7 +72,13 @@
         }
     ],
     "wof:id":1108959967,
-    "wof:lastmodified":1566644800,
+    "wof:lang_x_official":[
+        "slv"
+    ],
+    "wof:lang_x_spoken":[
+        "slv"
+    ],
+    "wof:lastmodified":1570054573,
     "wof:name":"Gorenjska",
     "wof:parent_id":85633779,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1718

Region records in Solvenia are "statistical regions," with `"mz:hierarchy_label":0` property values. This PR adds `wof:lang_x_official` and `wof:lang_x_spoken` properties to any region or localadmin records in Slovenia, with the same values as maintained in the country record for Slovenia (`slv` lang).

Requires no PIP work, can merge once approved.