### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/101/752/071/101752071.geojson
+++ b/data/101/752/071/101752071.geojson
@@ -429,6 +429,9 @@
         "wd:id":"Q1010"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"495e66fd1a391943f36f8f08723d5e2a",
     "wof:hierarchy":[
         {
@@ -443,7 +446,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644968,
+    "wof:lastmodified":1582358297,
     "wof:name":"Maribor",
     "wof:parent_id":1108959785,
     "wof:placetype":"locality",

--- a/data/101/752/073/101752073.geojson
+++ b/data/101/752/073/101752073.geojson
@@ -680,6 +680,9 @@
         "wk:page":"Ljubljana"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c5c0bf33062cf7176393f33cbb80e52c",
     "wof:hierarchy":[
         {
@@ -694,7 +697,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644968,
+    "wof:lastmodified":1582358298,
     "wof:megacity":0,
     "wof:name":"Ljubljana",
     "wof:parent_id":1108959501,

--- a/data/101/753/111/101753111.geojson
+++ b/data/101/753/111/101753111.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Limbu\u0161"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fef71df372d99b797d902a7e1d4b51f1",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":101753111,
-    "wof:lastmodified":1566644968,
+    "wof:lastmodified":1582358298,
     "wof:name":"Limbu\u0161",
     "wof:parent_id":1108959785,
     "wof:placetype":"locality",

--- a/data/101/791/141/101791141.geojson
+++ b/data/101/791/141/101791141.geojson
@@ -48,6 +48,9 @@
         "qs_pg:id":136303
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6a21a6ac28b294439e14fa5f3a499ea9",
     "wof:hierarchy":[
         {
@@ -59,7 +62,7 @@
         }
     ],
     "wof:id":101791141,
-    "wof:lastmodified":1566644974,
+    "wof:lastmodified":1582358299,
     "wof:name":"Sv. Trojica v Slov. goricah",
     "wof:parent_id":1108959801,
     "wof:placetype":"locality",

--- a/data/101/791/145/101791145.geojson
+++ b/data/101/791/145/101791145.geojson
@@ -227,6 +227,9 @@
         "wd:id":"Q15899"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cf7ad188878b12ca93c288355d5cc01b",
     "wof:hierarchy":[
         {
@@ -241,7 +244,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644970,
+    "wof:lastmodified":1582358299,
     "wof:name":"Murska Sobota",
     "wof:parent_id":1108959483,
     "wof:placetype":"locality",

--- a/data/101/791/147/101791147.geojson
+++ b/data/101/791/147/101791147.geojson
@@ -188,6 +188,9 @@
         "wk:page":"Turni\u0161\u010de"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"093593ce5a4b038060b9180442cb3fcf",
     "wof:hierarchy":[
         {
@@ -199,7 +202,7 @@
         }
     ],
     "wof:id":101791147,
-    "wof:lastmodified":1566644974,
+    "wof:lastmodified":1582358299,
     "wof:name":"Turni\u0161\u010de",
     "wof:parent_id":1108959603,
     "wof:placetype":"locality",

--- a/data/101/791/149/101791149.geojson
+++ b/data/101/791/149/101791149.geojson
@@ -191,6 +191,9 @@
         "wk:page":"Odranci"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6ae8f7b222d9fbb86635ef80378af49f",
     "wof:hierarchy":[
         {
@@ -202,7 +205,7 @@
         }
     ],
     "wof:id":101791149,
-    "wof:lastmodified":1566644974,
+    "wof:lastmodified":1582358299,
     "wof:name":"Odranci",
     "wof:parent_id":1108959595,
     "wof:placetype":"locality",

--- a/data/101/791/151/101791151.geojson
+++ b/data/101/791/151/101791151.geojson
@@ -240,6 +240,9 @@
         "wk:page":"Lendava"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6ce885bae1a6dbf3d1b0011d847a30a7",
     "wof:hierarchy":[
         {
@@ -254,7 +257,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644970,
+    "wof:lastmodified":1582358299,
     "wof:name":"Lendava",
     "wof:parent_id":1108959475,
     "wof:placetype":"locality",

--- a/data/101/791/153/101791153.geojson
+++ b/data/101/791/153/101791153.geojson
@@ -101,6 +101,9 @@
         "wk:page":"\u010cren\u0161ovci"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"571e36eb716df78c0f9a4d3392000b89",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":101791153,
-    "wof:lastmodified":1566644971,
+    "wof:lastmodified":1582358299,
     "wof:name":"\u010cren\u0161ovci",
     "wof:parent_id":1108959823,
     "wof:placetype":"locality",

--- a/data/101/791/155/101791155.geojson
+++ b/data/101/791/155/101791155.geojson
@@ -137,6 +137,9 @@
         "wk:page":"Beltinci"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c6790150f86f2966dbab38163ed42f0b",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
         }
     ],
     "wof:id":101791155,
-    "wof:lastmodified":1566644973,
+    "wof:lastmodified":1582358299,
     "wof:name":"Beltinci",
     "wof:parent_id":1108959517,
     "wof:placetype":"locality",

--- a/data/101/791/157/101791157.geojson
+++ b/data/101/791/157/101791157.geojson
@@ -93,6 +93,9 @@
         "qs_pg:id":1075923
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1422599c9221ce49762e70a306097986",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":101791157,
-    "wof:lastmodified":1566644969,
+    "wof:lastmodified":1582358298,
     "wof:name":"Kidri\u010devo",
     "wof:parent_id":1108959739,
     "wof:placetype":"locality",

--- a/data/101/791/159/101791159.geojson
+++ b/data/101/791/159/101791159.geojson
@@ -197,6 +197,9 @@
         "wk:page":"Ljutomer"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"145d711eed83700e1b2afb29828ed552",
     "wof:hierarchy":[
         {
@@ -211,7 +214,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644969,
+    "wof:lastmodified":1582358298,
     "wof:name":"Ljutomer",
     "wof:parent_id":1108959499,
     "wof:placetype":"locality",

--- a/data/101/791/163/101791163.geojson
+++ b/data/101/791/163/101791163.geojson
@@ -207,6 +207,9 @@
         "wd:id":"Q1944509"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6bd673213977451a11768d9071b5d30f",
     "wof:hierarchy":[
         {
@@ -221,7 +224,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644972,
+    "wof:lastmodified":1582358299,
     "wof:name":"Ormo\u017e",
     "wof:parent_id":1108959765,
     "wof:placetype":"locality",

--- a/data/101/791/165/101791165.geojson
+++ b/data/101/791/165/101791165.geojson
@@ -208,6 +208,9 @@
         "qs_pg:id":1343039
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e8966251548c421786bac6de107c3ab3",
     "wof:hierarchy":[
         {
@@ -219,7 +222,7 @@
         }
     ],
     "wof:id":101791165,
-    "wof:lastmodified":1566644972,
+    "wof:lastmodified":1582358299,
     "wof:name":"Miklav\u017e na Dravskem polju",
     "wof:parent_id":1108959665,
     "wof:placetype":"locality",

--- a/data/101/791/169/101791169.geojson
+++ b/data/101/791/169/101791169.geojson
@@ -90,6 +90,9 @@
         "wk:page":"Ra\u010de"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"31df1c33bba4a450f7eeae276909e30c",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":101791169,
-    "wof:lastmodified":1566644970,
+    "wof:lastmodified":1582358299,
     "wof:name":"Ra\u010de",
     "wof:parent_id":1108959589,
     "wof:placetype":"locality",

--- a/data/101/791/171/101791171.geojson
+++ b/data/101/791/171/101791171.geojson
@@ -89,6 +89,9 @@
         "wk:page":"Spodnje Ho\u010de"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6f667d84d37ee4da35e4b0900ab7f31e",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":101791171,
-    "wof:lastmodified":1566644975,
+    "wof:lastmodified":1582358299,
     "wof:name":"Spodnje Ho\u010de",
     "wof:parent_id":1108959749,
     "wof:placetype":"locality",

--- a/data/101/791/173/101791173.geojson
+++ b/data/101/791/173/101791173.geojson
@@ -78,6 +78,9 @@
         "qs_pg:id":147180
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1f452d47daf8ce6e9f7b7d629391b917",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":101791173,
-    "wof:lastmodified":1566644970,
+    "wof:lastmodified":1582358299,
     "wof:name":"Lovrenc na Pohorju",
     "wof:parent_id":1108959679,
     "wof:placetype":"locality",

--- a/data/101/791/175/101791175.geojson
+++ b/data/101/791/175/101791175.geojson
@@ -181,6 +181,9 @@
         "wd:id":"Q1917707"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7f7b340136d74203d6ba1d7a0c005340",
     "wof:hierarchy":[
         {
@@ -192,7 +195,7 @@
         }
     ],
     "wof:id":101791175,
-    "wof:lastmodified":1566644971,
+    "wof:lastmodified":1582358299,
     "wof:name":"Mislinja",
     "wof:parent_id":1108959467,
     "wof:placetype":"locality",

--- a/data/101/791/177/101791177.geojson
+++ b/data/101/791/177/101791177.geojson
@@ -109,6 +109,9 @@
         "wd:id":"Q6565933"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bbc46f6f19301f11d2db37ee73a7fc0e",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644974,
+    "wof:lastmodified":1582358299,
     "wof:name":"Radlje ob Dravi",
     "wof:parent_id":1108959557,
     "wof:placetype":"locality",

--- a/data/101/791/181/101791181.geojson
+++ b/data/101/791/181/101791181.geojson
@@ -102,6 +102,9 @@
         "qs_pg:id":1075971
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ea0cee996c70c5f57344ab692d02e840",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":101791181,
-    "wof:lastmodified":1566644971,
+    "wof:lastmodified":1582358299,
     "wof:name":"Muta",
     "wof:parent_id":1108959677,
     "wof:placetype":"locality",

--- a/data/101/791/183/101791183.geojson
+++ b/data/101/791/183/101791183.geojson
@@ -199,6 +199,9 @@
         "wd:id":"Q15898"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8ffce5391d38b6c851702203108a1e4b",
     "wof:hierarchy":[
         {
@@ -210,7 +213,7 @@
         }
     ],
     "wof:id":101791183,
-    "wof:lastmodified":1566644974,
+    "wof:lastmodified":1582358299,
     "wof:name":"Me\u017eica",
     "wof:parent_id":1108959479,
     "wof:placetype":"locality",

--- a/data/101/791/185/101791185.geojson
+++ b/data/101/791/185/101791185.geojson
@@ -97,6 +97,9 @@
         "qs_pg:id":963579
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1aa148403a13621f208d68a8d0dbd792",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":101791185,
-    "wof:lastmodified":1566644975,
+    "wof:lastmodified":1582358299,
     "wof:name":"\u010crna na Koro\u0161kem",
     "wof:parent_id":1108959573,
     "wof:placetype":"locality",

--- a/data/101/791/187/101791187.geojson
+++ b/data/101/791/187/101791187.geojson
@@ -132,6 +132,9 @@
         "qs_pg:id":1043976
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"01f9162cd8dc43baccc0a50be21c714d",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":101791187,
-    "wof:lastmodified":1566644970,
+    "wof:lastmodified":1582358299,
     "wof:name":"Prevalje",
     "wof:parent_id":1108959695,
     "wof:placetype":"locality",

--- a/data/101/791/987/101791987.geojson
+++ b/data/101/791/987/101791987.geojson
@@ -188,6 +188,9 @@
         "wk:page":"Dobrovnik"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"da9f3a25ed6897281b7af80292fc3a07",
     "wof:hierarchy":[
         {
@@ -199,7 +202,7 @@
         }
     ],
     "wof:id":101791987,
-    "wof:lastmodified":1566644973,
+    "wof:lastmodified":1582358299,
     "wof:name":"Dobrovnik",
     "wof:parent_id":1108959691,
     "wof:placetype":"locality",

--- a/data/101/791/995/101791995.geojson
+++ b/data/101/791/995/101791995.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Dornava"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3b73dd2c0515d80b45a77d0d685d2019",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":101791995,
-    "wof:lastmodified":1566644972,
+    "wof:lastmodified":1582358299,
     "wof:name":"Dornava",
     "wof:parent_id":1108959761,
     "wof:placetype":"locality",

--- a/data/101/791/997/101791997.geojson
+++ b/data/101/791/997/101791997.geojson
@@ -218,6 +218,9 @@
         "wd:id":"Q15917"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4d8a93ce4c4c6d13f7612e03bb0030a1",
     "wof:hierarchy":[
         {
@@ -232,7 +235,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644969,
+    "wof:lastmodified":1582358299,
     "wof:name":"Slovenska Bistrica",
     "wof:parent_id":1108959641,
     "wof:placetype":"locality",

--- a/data/101/791/999/101791999.geojson
+++ b/data/101/791/999/101791999.geojson
@@ -330,6 +330,9 @@
         "wd:id":"Q15918"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"27ec50e1bc3eb987176fd127a92cdadd",
     "wof:hierarchy":[
         {
@@ -344,7 +347,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644970,
+    "wof:lastmodified":1582358299,
     "wof:name":"Slovenj Gradec",
     "wof:parent_id":1108959645,
     "wof:placetype":"locality",

--- a/data/101/792/001/101792001.geojson
+++ b/data/101/792/001/101792001.geojson
@@ -230,6 +230,9 @@
         "qs_pg:id":529444
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e2d0f96af0dd3d84cfdcbef0954775cd",
     "wof:hierarchy":[
         {
@@ -244,7 +247,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645001,
+    "wof:lastmodified":1582358303,
     "wof:name":"Ravne na Koro\u0161kem",
     "wof:parent_id":1108959643,
     "wof:placetype":"locality",

--- a/data/101/792/005/101792005.geojson
+++ b/data/101/792/005/101792005.geojson
@@ -93,6 +93,9 @@
         "qs_pg:id":1078937
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a721811222f46987c0b5fb954ba8e7d2",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":101792005,
-    "wof:lastmodified":1566645006,
+    "wof:lastmodified":1582358304,
     "wof:name":"Tabor",
     "wof:parent_id":1108959715,
     "wof:placetype":"locality",

--- a/data/101/792/009/101792009.geojson
+++ b/data/101/792/009/101792009.geojson
@@ -117,6 +117,9 @@
         "qs_pg:id":343358
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eb18b5c90977a5dab97f6082f556a75e",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":101792009,
-    "wof:lastmodified":1566645001,
+    "wof:lastmodified":1582358303,
     "wof:name":"Re\u010dica ob Savinji",
     "wof:parent_id":1108959809,
     "wof:placetype":"locality",

--- a/data/101/792/011/101792011.geojson
+++ b/data/101/792/011/101792011.geojson
@@ -93,6 +93,9 @@
         "wk:page":"Dobrova, Dobrova\u2013Polhov Gradec"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ea94880910c7cf430309e6fdb350ca0e",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":101792011,
-    "wof:lastmodified":1566645003,
+    "wof:lastmodified":1582358304,
     "wof:name":"Dobrova",
     "wof:parent_id":1108959847,
     "wof:placetype":"locality",

--- a/data/101/792/013/101792013.geojson
+++ b/data/101/792/013/101792013.geojson
@@ -113,6 +113,9 @@
         "wk:page":"\u0160tore"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e90a72c80db8863c78afba44cd854f64",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101792013,
-    "wof:lastmodified":1566644999,
+    "wof:lastmodified":1582358303,
     "wof:name":"\u0160tore",
     "wof:parent_id":1108959631,
     "wof:placetype":"locality",

--- a/data/101/792/017/101792017.geojson
+++ b/data/101/792/017/101792017.geojson
@@ -203,6 +203,9 @@
         "wk:page":"Rade\u010de"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ef9154ffcaf7f4d5e5422436617079e4",
     "wof:hierarchy":[
         {
@@ -214,7 +217,7 @@
         }
     ],
     "wof:id":101792017,
-    "wof:lastmodified":1566645004,
+    "wof:lastmodified":1582358304,
     "wof:name":"Rade\u010de",
     "wof:parent_id":1108959883,
     "wof:placetype":"locality",

--- a/data/101/792/021/101792021.geojson
+++ b/data/101/792/021/101792021.geojson
@@ -113,6 +113,9 @@
         "wd:id":"Q594852"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"515fb9b17ebbe8e30ebcecb91b1749a5",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101792021,
-    "wof:lastmodified":1566645004,
+    "wof:lastmodified":1582358304,
     "wof:name":"Polj\u010dane",
     "wof:parent_id":1108959721,
     "wof:placetype":"locality",

--- a/data/101/792/023/101792023.geojson
+++ b/data/101/792/023/101792023.geojson
@@ -153,6 +153,9 @@
         "wk:page":"\u0160entjur"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"24c6e78ad64d88639a6f4d41f9ec8718",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
         }
     ],
     "wof:id":101792023,
-    "wof:lastmodified":1566644998,
+    "wof:lastmodified":1582358303,
     "wof:name":"\u0160entjur",
     "wof:parent_id":1108959791,
     "wof:placetype":"locality",

--- a/data/101/792/027/101792027.geojson
+++ b/data/101/792/027/101792027.geojson
@@ -221,6 +221,9 @@
         "wd:id":"Q15919"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a328f354f8ca1192df04629f9b17099b",
     "wof:hierarchy":[
         {
@@ -235,7 +238,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645003,
+    "wof:lastmodified":1582358304,
     "wof:name":"Slovenske Konjice",
     "wof:parent_id":1108959753,
     "wof:placetype":"locality",

--- a/data/101/792/029/101792029.geojson
+++ b/data/101/792/029/101792029.geojson
@@ -93,6 +93,9 @@
         "qs_pg:id":582719
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9b31fdde60a7d7afd09bcdb872c4d616",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":101792029,
-    "wof:lastmodified":1566645004,
+    "wof:lastmodified":1582358304,
     "wof:name":"Zre\u010de",
     "wof:parent_id":1108959671,
     "wof:placetype":"locality",

--- a/data/101/792/031/101792031.geojson
+++ b/data/101/792/031/101792031.geojson
@@ -344,6 +344,9 @@
         "wk:page":"Celje"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6ce55a4bc322a45a6ba439249c9d8715",
     "wof:hierarchy":[
         {
@@ -358,7 +361,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645001,
+    "wof:lastmodified":1582358303,
     "wof:name":"Celje",
     "wof:parent_id":1108959693,
     "wof:placetype":"locality",

--- a/data/101/792/033/101792033.geojson
+++ b/data/101/792/033/101792033.geojson
@@ -121,6 +121,9 @@
         "wd:id":"Q16469"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0f8e2b877e51ca2c1998b202fbde15f9",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":101792033,
-    "wof:lastmodified":1566645005,
+    "wof:lastmodified":1582358304,
     "wof:name":"Vojnik",
     "wof:parent_id":1108959653,
     "wof:placetype":"locality",

--- a/data/101/792/035/101792035.geojson
+++ b/data/101/792/035/101792035.geojson
@@ -247,6 +247,9 @@
         "wk:page":"Municipality of Trbovlje"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a17ab5594e07b4c9b732f9c2c9ede5b0",
     "wof:hierarchy":[
         {
@@ -261,7 +264,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645005,
+    "wof:lastmodified":1582358304,
     "wof:name":"Trbovlje",
     "wof:parent_id":1108959911,
     "wof:placetype":"locality",

--- a/data/101/792/037/101792037.geojson
+++ b/data/101/792/037/101792037.geojson
@@ -85,6 +85,9 @@
         "wk:page":"Izlake"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"32c6931dabb60184eee100395ab2719c",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645001,
+    "wof:lastmodified":1582358303,
     "wof:name":"Izlake",
     "wof:parent_id":1108959683,
     "wof:placetype":"locality",

--- a/data/101/792/039/101792039.geojson
+++ b/data/101/792/039/101792039.geojson
@@ -101,6 +101,9 @@
         "wd:id":"Q2354085"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"945dbd9d1cb1c4432dd1bbff26a4ed85",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645001,
+    "wof:lastmodified":1582358303,
     "wof:name":"Mozirje",
     "wof:parent_id":1108959485,
     "wof:placetype":"locality",

--- a/data/101/792/041/101792041.geojson
+++ b/data/101/792/041/101792041.geojson
@@ -150,6 +150,9 @@
         "wd:id":"Q631387"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"87c9e0fd9b045a5e9227cc2f7fb8131f",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644999,
+    "wof:lastmodified":1582358303,
     "wof:name":"\u017dalec",
     "wof:parent_id":1108959929,
     "wof:placetype":"locality",

--- a/data/101/792/053/101792053.geojson
+++ b/data/101/792/053/101792053.geojson
@@ -137,6 +137,9 @@
         "qs_pg:id":1060361
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eaa9ffd6cc0c38e566ff52ea5eb1d088",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
         }
     ],
     "wof:id":101792053,
-    "wof:lastmodified":1566645000,
+    "wof:lastmodified":1582358303,
     "wof:name":"Cerkno",
     "wof:parent_id":1108959577,
     "wof:placetype":"locality",

--- a/data/101/792/055/101792055.geojson
+++ b/data/101/792/055/101792055.geojson
@@ -134,6 +134,9 @@
         "wk:page":"Tolmin"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4e174eb13bce820b173707e0a998693a",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645001,
+    "wof:lastmodified":1582358303,
     "wof:name":"Tolmin",
     "wof:parent_id":1108959617,
     "wof:placetype":"locality",

--- a/data/101/792/059/101792059.geojson
+++ b/data/101/792/059/101792059.geojson
@@ -196,6 +196,9 @@
         "qs_pg:id":1301684
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"88ca762c81e25dcb919c5e462107f6c6",
     "wof:hierarchy":[
         {
@@ -210,7 +213,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645005,
+    "wof:lastmodified":1582358304,
     "wof:name":"Jesenice",
     "wof:parent_id":1108959875,
     "wof:placetype":"locality",

--- a/data/101/792/065/101792065.geojson
+++ b/data/101/792/065/101792065.geojson
@@ -170,6 +170,9 @@
         "wk:page":"Kobarid"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3f6aeed74a944348951018c8a7517b94",
     "wof:hierarchy":[
         {
@@ -181,7 +184,7 @@
         }
     ],
     "wof:id":101792065,
-    "wof:lastmodified":1566645000,
+    "wof:lastmodified":1582358303,
     "wof:name":"Kobarid",
     "wof:parent_id":1108959523,
     "wof:placetype":"locality",

--- a/data/101/792/067/101792067.geojson
+++ b/data/101/792/067/101792067.geojson
@@ -152,6 +152,9 @@
         "wk:page":"Medvode"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3862ff87f89bff7ae15fd17821472578",
     "wof:hierarchy":[
         {
@@ -163,7 +166,7 @@
         }
     ],
     "wof:id":101792067,
-    "wof:lastmodified":1566645006,
+    "wof:lastmodified":1582358304,
     "wof:name":"Medvode",
     "wof:parent_id":1108959881,
     "wof:placetype":"locality",

--- a/data/101/792/069/101792069.geojson
+++ b/data/101/792/069/101792069.geojson
@@ -91,6 +91,9 @@
         "qs_pg:id":1043933
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2c1aee018c881636b7bd252f00a31b94",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":101792069,
-    "wof:lastmodified":1566645006,
+    "wof:lastmodified":1582358304,
     "wof:name":"\u0160en\u010dur",
     "wof:parent_id":1108959647,
     "wof:placetype":"locality",

--- a/data/101/792/073/101792073.geojson
+++ b/data/101/792/073/101792073.geojson
@@ -152,6 +152,9 @@
         "wd:id":"Q15871"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"24a7c55e19e970082e024bfe78e152fe",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645003,
+    "wof:lastmodified":1582358304,
     "wof:name":"Hrastnik",
     "wof:parent_id":1108959571,
     "wof:placetype":"locality",

--- a/data/101/792/075/101792075.geojson
+++ b/data/101/792/075/101792075.geojson
@@ -175,6 +175,9 @@
         "wk:page":"Zagorje ob Savi"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2fcfc4ac84a2c8933af3752c684b58b8",
     "wof:hierarchy":[
         {
@@ -189,7 +192,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645004,
+    "wof:lastmodified":1582358304,
     "wof:name":"Zagorje ob Savi",
     "wof:parent_id":1108959683,
     "wof:placetype":"locality",

--- a/data/101/792/081/101792081.geojson
+++ b/data/101/792/081/101792081.geojson
@@ -117,6 +117,9 @@
         "qs_pg:id":977070
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"791f34b7145b1bf5b94789da48dfd6be",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":101792081,
-    "wof:lastmodified":1566645004,
+    "wof:lastmodified":1582358304,
     "wof:name":"Preddvor",
     "wof:parent_id":1108959657,
     "wof:placetype":"locality",

--- a/data/101/792/083/101792083.geojson
+++ b/data/101/792/083/101792083.geojson
@@ -123,6 +123,9 @@
         "wk:page":"Radovljica"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d52bcd27a9b81b1aaa3a6142aecc537f",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644999,
+    "wof:lastmodified":1582358303,
     "wof:name":"Radovljica",
     "wof:parent_id":1108959825,
     "wof:placetype":"locality",

--- a/data/101/792/085/101792085.geojson
+++ b/data/101/792/085/101792085.geojson
@@ -212,6 +212,9 @@
         "wk:page":"Bled"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"425397f023e0b1f9fe89099242210f0b",
     "wof:hierarchy":[
         {
@@ -223,7 +226,7 @@
         }
     ],
     "wof:id":101792085,
-    "wof:lastmodified":1566645000,
+    "wof:lastmodified":1582358303,
     "wof:name":"Bled",
     "wof:parent_id":1108959797,
     "wof:placetype":"locality",

--- a/data/101/792/965/101792965.geojson
+++ b/data/101/792/965/101792965.geojson
@@ -90,6 +90,9 @@
         "wk:page":"Dragomer"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8e7cf0bd49c6561c5fca0946e7468dfe",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":101792965,
-    "wof:lastmodified":1566644998,
+    "wof:lastmodified":1582358303,
     "wof:name":"Dragomer",
     "wof:parent_id":1108959877,
     "wof:placetype":"locality",

--- a/data/101/792/967/101792967.geojson
+++ b/data/101/792/967/101792967.geojson
@@ -87,6 +87,9 @@
         "wk:page":"\u0160empas"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d014e1b3e819957854e34b758e311b2e",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":101792967,
-    "wof:lastmodified":1566645003,
+    "wof:lastmodified":1582358304,
     "wof:name":"\u0160empas",
     "wof:parent_id":1108959487,
     "wof:placetype":"locality",

--- a/data/101/792/969/101792969.geojson
+++ b/data/101/792/969/101792969.geojson
@@ -93,6 +93,9 @@
         "wk:page":"Vrtojba"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"05926826dd8f09dbedbd67c3a3f0e9e6",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":101792969,
-    "wof:lastmodified":1566645003,
+    "wof:lastmodified":1582358304,
     "wof:name":"Vrtojba",
     "wof:parent_id":1108959629,
     "wof:placetype":"locality",

--- a/data/101/792/971/101792971.geojson
+++ b/data/101/792/971/101792971.geojson
@@ -115,6 +115,9 @@
         "wk:page":"Municipality of Stra\u017ea"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"42d9ebf647df5f1d8c73265344f91754",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":101792971,
-    "wof:lastmodified":1566645002,
+    "wof:lastmodified":1582358303,
     "wof:name":"Stra\u017ea",
     "wof:parent_id":1108959793,
     "wof:placetype":"locality",

--- a/data/101/792/973/101792973.geojson
+++ b/data/101/792/973/101792973.geojson
@@ -255,6 +255,9 @@
         "wk:page":"Novo Mesto"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4a002c9b4579bf2472334f6b96d87a5d",
     "wof:hierarchy":[
         {
@@ -269,7 +272,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645006,
+    "wof:lastmodified":1582358304,
     "wof:name":"Novo mesto",
     "wof:parent_id":1108959465,
     "wof:placetype":"locality",

--- a/data/101/792/977/101792977.geojson
+++ b/data/101/792/977/101792977.geojson
@@ -150,6 +150,9 @@
         "wk:page":"Trebnje"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c5a315a23d08e9c12f5ea18757335be7",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645001,
+    "wof:lastmodified":1582358303,
     "wof:name":"Trebnje",
     "wof:parent_id":1108959839,
     "wof:placetype":"locality",

--- a/data/101/792/981/101792981.geojson
+++ b/data/101/792/981/101792981.geojson
@@ -152,6 +152,9 @@
         "wd:id":"Q15915"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d0b7f35a9e569b1a560c7259df7dc8c3",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645007,
+    "wof:lastmodified":1582358304,
     "wof:name":"Sevnica",
     "wof:parent_id":1108959927,
     "wof:placetype":"locality",

--- a/data/101/792/983/101792983.geojson
+++ b/data/101/792/983/101792983.geojson
@@ -115,6 +115,9 @@
         "wk:page":"Mirna (settlement)"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d4c7ac1259d0c1e4aff1ec2de0bd08fe",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645002,
+    "wof:lastmodified":1582358303,
     "wof:name":"Mirna",
     "wof:parent_id":1108959869,
     "wof:placetype":"locality",

--- a/data/101/792/985/101792985.geojson
+++ b/data/101/792/985/101792985.geojson
@@ -202,6 +202,9 @@
         "qs_pg:id":977083
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"106f7ae34ddc36e29f1899c8ba11d77b",
     "wof:hierarchy":[
         {
@@ -213,7 +216,7 @@
         }
     ],
     "wof:id":101792985,
-    "wof:lastmodified":1566645002,
+    "wof:lastmodified":1582358303,
     "wof:name":"\u017du\u017eemberk",
     "wof:parent_id":1108959787,
     "wof:placetype":"locality",

--- a/data/101/792/987/101792987.geojson
+++ b/data/101/792/987/101792987.geojson
@@ -139,6 +139,9 @@
         "qs_pg:id":1043886
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0947e738b788301319e452e56323045d",
     "wof:hierarchy":[
         {
@@ -150,7 +153,7 @@
         }
     ],
     "wof:id":101792987,
-    "wof:lastmodified":1566645006,
+    "wof:lastmodified":1582358304,
     "wof:name":"Vipava",
     "wof:parent_id":1108959623,
     "wof:placetype":"locality",

--- a/data/101/792/989/101792989.geojson
+++ b/data/101/792/989/101792989.geojson
@@ -97,6 +97,9 @@
         "wk:page":"Rakek"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9cbcbe763bb72c109b9565b57df01841",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566645007,
+    "wof:lastmodified":1582358304,
     "wof:name":"Rakek",
     "wof:parent_id":1108959905,
     "wof:placetype":"locality",

--- a/data/101/792/991/101792991.geojson
+++ b/data/101/792/991/101792991.geojson
@@ -173,6 +173,9 @@
         "wk:page":"\u0160kofljica"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ccb99257be7d27014d6c3416dc8df3fb",
     "wof:hierarchy":[
         {
@@ -184,7 +187,7 @@
         }
     ],
     "wof:id":101792991,
-    "wof:lastmodified":1566644998,
+    "wof:lastmodified":1582358303,
     "wof:name":"\u0160kofljica",
     "wof:parent_id":1108959891,
     "wof:placetype":"locality",

--- a/data/101/792/993/101792993.geojson
+++ b/data/101/792/993/101792993.geojson
@@ -99,6 +99,9 @@
         "wk:page":"Ig, Ig"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7cbe2b89eef58c317d7175e0c8fee155",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":101792993,
-    "wof:lastmodified":1566645002,
+    "wof:lastmodified":1582358304,
     "wof:name":"Ig",
     "wof:parent_id":1108959887,
     "wof:placetype":"locality",

--- a/data/101/792/995/101792995.geojson
+++ b/data/101/792/995/101792995.geojson
@@ -131,6 +131,9 @@
         "wk:page":"Borovnica, Borovnica"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1f51d8aceabdad812209fd59d8622b87",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
         }
     ],
     "wof:id":101792995,
-    "wof:lastmodified":1566645002,
+    "wof:lastmodified":1582358303,
     "wof:name":"Borovnica",
     "wof:parent_id":1108959871,
     "wof:placetype":"locality",

--- a/data/101/792/999/101792999.geojson
+++ b/data/101/792/999/101792999.geojson
@@ -92,6 +92,9 @@
         "wk:page":"Horjul, Horjul"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5f79a6519638e1bcdd6a52000bc276ef",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":101792999,
-    "wof:lastmodified":1566644998,
+    "wof:lastmodified":1582358303,
     "wof:name":"Horjul",
     "wof:parent_id":1108959865,
     "wof:placetype":"locality",

--- a/data/101/793/001/101793001.geojson
+++ b/data/101/793/001/101793001.geojson
@@ -186,6 +186,9 @@
         "wk:page":"\u017diri"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0bea620bf94e8882da586388d66b8122",
     "wof:hierarchy":[
         {
@@ -197,7 +200,7 @@
         }
     ],
     "wof:id":101793001,
-    "wof:lastmodified":1566644995,
+    "wof:lastmodified":1582358302,
     "wof:name":"\u017diri",
     "wof:parent_id":1108959673,
     "wof:placetype":"locality",

--- a/data/101/793/003/101793003.geojson
+++ b/data/101/793/003/101793003.geojson
@@ -96,6 +96,9 @@
         "qs_pg:id":226842
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"684eb5613cb38ffb52cd3ece1b7eec00",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":101793003,
-    "wof:lastmodified":1566644995,
+    "wof:lastmodified":1582358302,
     "wof:name":"Miren",
     "wof:parent_id":1108959481,
     "wof:placetype":"locality",

--- a/data/101/793/009/101793009.geojson
+++ b/data/101/793/009/101793009.geojson
@@ -234,6 +234,9 @@
         "qs_pg:id":1078927
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0056128c9b143dc8b1518eff7081923e",
     "wof:hierarchy":[
         {
@@ -245,7 +248,7 @@
         }
     ],
     "wof:id":101793009,
-    "wof:lastmodified":1566644994,
+    "wof:lastmodified":1582358302,
     "wof:name":"Kr\u0161ko",
     "wof:parent_id":1108959473,
     "wof:placetype":"locality",

--- a/data/101/793/013/101793013.geojson
+++ b/data/101/793/013/101793013.geojson
@@ -100,6 +100,9 @@
         "wk:page":"Nova Vas, Bloke"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ca86b5e2542d4e23020265a50c78855b",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":101793013,
-    "wof:lastmodified":1566644994,
+    "wof:lastmodified":1582358302,
     "wof:name":"Nova vas",
     "wof:parent_id":1108959893,
     "wof:placetype":"locality",

--- a/data/101/793/019/101793019.geojson
+++ b/data/101/793/019/101793019.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Logatec"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c67438e98b51fe6d23ab68719695988e",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":101793019,
-    "wof:lastmodified":1566644995,
+    "wof:lastmodified":1582358302,
     "wof:name":"Logatec",
     "wof:parent_id":1108959889,
     "wof:placetype":"locality",

--- a/data/101/793/021/101793021.geojson
+++ b/data/101/793/021/101793021.geojson
@@ -160,6 +160,9 @@
         "wk:page":"Ajdov\u0161\u010dina"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"26231b823717bd6a3932d2f107171c0d",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
         }
     ],
     "wof:id":101793021,
-    "wof:lastmodified":1566644995,
+    "wof:lastmodified":1582358302,
     "wof:name":"Ajdov\u0161\u010dina",
     "wof:parent_id":1108959545,
     "wof:placetype":"locality",

--- a/data/101/793/023/101793023.geojson
+++ b/data/101/793/023/101793023.geojson
@@ -129,6 +129,9 @@
         "wk:page":"Komen"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"55d4d5f58b7c5f46e820422b88f840aa",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":101793023,
-    "wof:lastmodified":1566644994,
+    "wof:lastmodified":1582358302,
     "wof:name":"Komen",
     "wof:parent_id":1108959539,
     "wof:placetype":"locality",

--- a/data/101/793/025/101793025.geojson
+++ b/data/101/793/025/101793025.geojson
@@ -150,6 +150,9 @@
         "wk:page":"Grosuplje"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5e598f956d0f48717915ccdf99729c15",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644994,
+    "wof:lastmodified":1582358302,
     "wof:name":"Grosuplje",
     "wof:parent_id":1108959533,
     "wof:placetype":"locality",

--- a/data/101/794/111/101794111.geojson
+++ b/data/101/794/111/101794111.geojson
@@ -289,6 +289,9 @@
         "wd:id":"Q1015"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"90a909210b834408c0023927110c0207",
     "wof:hierarchy":[
         {
@@ -303,7 +306,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644996,
+    "wof:lastmodified":1582358302,
     "wof:name":"Koper",
     "wof:parent_id":1108959527,
     "wof:placetype":"locality",

--- a/data/101/794/115/101794115.geojson
+++ b/data/101/794/115/101794115.geojson
@@ -252,6 +252,9 @@
         "wd:id":"Q15877"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eb9f34026e9a29ac96aab319d50dce9c",
     "wof:hierarchy":[
         {
@@ -266,7 +269,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644997,
+    "wof:lastmodified":1582358303,
     "wof:name":"Izola",
     "wof:parent_id":1108959551,
     "wof:placetype":"locality",

--- a/data/101/794/117/101794117.geojson
+++ b/data/101/794/117/101794117.geojson
@@ -316,6 +316,9 @@
         "wk:page":"Ankaran"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9cba5b5437e7afa157520aaa347e5346",
     "wof:hierarchy":[
         {
@@ -327,7 +330,7 @@
         }
     ],
     "wof:id":101794117,
-    "wof:lastmodified":1566644997,
+    "wof:lastmodified":1582358303,
     "wof:name":"Ankaran",
     "wof:parent_id":1108959857,
     "wof:placetype":"locality",

--- a/data/101/794/119/101794119.geojson
+++ b/data/101/794/119/101794119.geojson
@@ -115,6 +115,9 @@
         "wd:id":"Q1230519"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bfd3b65847fbd564621cd9bfc4a9b017",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":101794119,
-    "wof:lastmodified":1566644997,
+    "wof:lastmodified":1582358303,
     "wof:name":"Diva\u010da",
     "wof:parent_id":1108959845,
     "wof:placetype":"locality",

--- a/data/101/794/121/101794121.geojson
+++ b/data/101/794/121/101794121.geojson
@@ -123,6 +123,9 @@
         "qs_pg:id":1075991
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fbd604685bc68cae47336e017e415531",
     "wof:hierarchy":[
         {
@@ -134,7 +137,7 @@
         }
     ],
     "wof:id":101794121,
-    "wof:lastmodified":1566644997,
+    "wof:lastmodified":1582358303,
     "wof:name":"Pivka",
     "wof:parent_id":1108959587,
     "wof:placetype":"locality",

--- a/data/101/794/123/101794123.geojson
+++ b/data/101/794/123/101794123.geojson
@@ -227,6 +227,9 @@
         "wd:id":"Q15876"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c5f57f3df5c0095180211aabf76f2d32",
     "wof:hierarchy":[
         {
@@ -241,7 +244,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644997,
+    "wof:lastmodified":1582358303,
     "wof:name":"Ilirska Bistrica",
     "wof:parent_id":1108959873,
     "wof:placetype":"locality",

--- a/data/101/794/125/101794125.geojson
+++ b/data/101/794/125/101794125.geojson
@@ -171,6 +171,9 @@
         "wk:page":"Se\u017eana"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5e3d43831513d57708532adf06ce4f5d",
     "wof:hierarchy":[
         {
@@ -185,7 +188,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644997,
+    "wof:lastmodified":1582358303,
     "wof:name":"Se\u017eana",
     "wof:parent_id":1108959789,
     "wof:placetype":"locality",

--- a/data/101/794/129/101794129.geojson
+++ b/data/101/794/129/101794129.geojson
@@ -170,6 +170,9 @@
         "wk:page":"Ko\u010devje"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"12febf3886498bbe291764c709f15135",
     "wof:hierarchy":[
         {
@@ -184,7 +187,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644996,
+    "wof:lastmodified":1582358302,
     "wof:name":"Ko\u010devje",
     "wof:parent_id":1108959919,
     "wof:placetype":"locality",

--- a/data/101/794/133/101794133.geojson
+++ b/data/101/794/133/101794133.geojson
@@ -165,6 +165,9 @@
         "wd:id":"Q15861"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ff21103f8d89b3d4caabdbc8fa87c8af",
     "wof:hierarchy":[
         {
@@ -179,7 +182,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644996,
+    "wof:lastmodified":1582358302,
     "wof:name":"\u010crnomelj",
     "wof:parent_id":1108959699,
     "wof:placetype":"locality",

--- a/data/101/794/135/101794135.geojson
+++ b/data/101/794/135/101794135.geojson
@@ -221,6 +221,9 @@
         "wd:id":"Q15901"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"74b9ac4bc2a723d6696cdde7e8b12ef4",
     "wof:hierarchy":[
         {
@@ -235,7 +238,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644996,
+    "wof:lastmodified":1582358302,
     "wof:name":"Postojna",
     "wof:parent_id":1108959559,
     "wof:placetype":"locality",

--- a/data/101/835/159/101835159.geojson
+++ b/data/101/835/159/101835159.geojson
@@ -269,6 +269,9 @@
         "wd:id":"Q15906"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"05594fa5e7f032441c99400adfb7d553",
     "wof:hierarchy":[
         {
@@ -283,7 +286,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644988,
+    "wof:lastmodified":1582358301,
     "wof:name":"Ptuj",
     "wof:parent_id":1108959659,
     "wof:placetype":"locality",

--- a/data/101/835/163/101835163.geojson
+++ b/data/101/835/163/101835163.geojson
@@ -217,6 +217,9 @@
         "wk:page":"Gornja Radgona"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5280f00c6b0f573ad44901d690d38764",
     "wof:hierarchy":[
         {
@@ -231,7 +234,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644990,
+    "wof:lastmodified":1582358301,
     "wof:name":"Gornja Radgona",
     "wof:parent_id":1108959817,
     "wof:placetype":"locality",

--- a/data/101/835/165/101835165.geojson
+++ b/data/101/835/165/101835165.geojson
@@ -255,6 +255,9 @@
         "wd:id":"Q15928"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"03634451c2fb72ea5c730ae11d7b9f05",
     "wof:hierarchy":[
         {
@@ -269,7 +272,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644990,
+    "wof:lastmodified":1582358301,
     "wof:name":"Velenje",
     "wof:parent_id":1108959593,
     "wof:placetype":"locality",

--- a/data/101/835/167/101835167.geojson
+++ b/data/101/835/167/101835167.geojson
@@ -242,6 +242,9 @@
         "wk:page":"\u0160o\u0161tanj"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f8cd3eba9d79a2ab5d8c553548083643",
     "wof:hierarchy":[
         {
@@ -253,7 +256,7 @@
         }
     ],
     "wof:id":101835167,
-    "wof:lastmodified":1566644989,
+    "wof:lastmodified":1582358301,
     "wof:name":"\u0160o\u0161tanj",
     "wof:parent_id":1108959731,
     "wof:placetype":"locality",

--- a/data/101/835/169/101835169.geojson
+++ b/data/101/835/169/101835169.geojson
@@ -201,6 +201,9 @@
         "wk:page":"Kamnik"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fd6e64d133ea420b92618dc2fe95fa3c",
     "wof:hierarchy":[
         {
@@ -215,7 +218,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644989,
+    "wof:lastmodified":1582358301,
     "wof:name":"Kamnik",
     "wof:parent_id":1108959941,
     "wof:placetype":"locality",

--- a/data/101/835/173/101835173.geojson
+++ b/data/101/835/173/101835173.geojson
@@ -238,6 +238,9 @@
         "wk:page":"Dom\u017eale"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4509e734edbff81b5b746661e6da2c45",
     "wof:hierarchy":[
         {
@@ -252,7 +255,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644989,
+    "wof:lastmodified":1582358301,
     "wof:name":"Dom\u017eale",
     "wof:parent_id":1108959799,
     "wof:placetype":"locality",

--- a/data/101/835/175/101835175.geojson
+++ b/data/101/835/175/101835175.geojson
@@ -235,6 +235,9 @@
         "wd:id":"Q1021"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bb79ea7d1f7d1640346134c20c8a4950",
     "wof:hierarchy":[
         {
@@ -249,7 +252,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644989,
+    "wof:lastmodified":1582358301,
     "wof:name":"Kranj",
     "wof:parent_id":1108959933,
     "wof:placetype":"locality",

--- a/data/101/835/955/101835955.geojson
+++ b/data/101/835/955/101835955.geojson
@@ -129,6 +129,9 @@
         "wk:page":"\u0160empeter pri Gorici"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6552a6eacc1000114d25f4657894612c",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":101835955,
-    "wof:lastmodified":1566644989,
+    "wof:lastmodified":1582358301,
     "wof:name":"\u0160empeter pri Gorici",
     "wof:parent_id":1108959629,
     "wof:placetype":"locality",

--- a/data/101/835/957/101835957.geojson
+++ b/data/101/835/957/101835957.geojson
@@ -231,6 +231,9 @@
         "wk:page":"Nova Gorica"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"080563007b0e6cbe25d6ddcd731ab351",
     "wof:hierarchy":[
         {
@@ -245,7 +248,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644990,
+    "wof:lastmodified":1582358301,
     "wof:name":"Nova Gorica",
     "wof:parent_id":1108959487,
     "wof:placetype":"locality",

--- a/data/101/835/965/101835965.geojson
+++ b/data/101/835/965/101835965.geojson
@@ -103,6 +103,9 @@
         "wk:page":"Lucija, Piran"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5550e26f6eb3417bc6fcad84d6743291",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644988,
+    "wof:lastmodified":1582358301,
     "wof:name":"Lucija",
     "wof:parent_id":1108959613,
     "wof:placetype":"locality",

--- a/data/101/845/257/101845257.geojson
+++ b/data/101/845/257/101845257.geojson
@@ -101,6 +101,9 @@
         "wk:page":"Lesce"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7680f8701a1f258a90facb43bf0a5cc8",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644977,
+    "wof:lastmodified":1582358300,
     "wof:name":"Lesce",
     "wof:parent_id":1108959825,
     "wof:placetype":"locality",

--- a/data/101/845/259/101845259.geojson
+++ b/data/101/845/259/101845259.geojson
@@ -97,6 +97,9 @@
         "wk:page":"Pragersko"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bc527461c52b4ae08e007d0d905dc44b",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644978,
+    "wof:lastmodified":1582358300,
     "wof:name":"Pragersko",
     "wof:parent_id":1108959641,
     "wof:placetype":"locality",

--- a/data/101/845/261/101845261.geojson
+++ b/data/101/845/261/101845261.geojson
@@ -216,6 +216,9 @@
         "wd:id":"Q15896"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"92b31ba8084a6c0613e32e98d7277633",
     "wof:hierarchy":[
         {
@@ -230,7 +233,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644978,
+    "wof:lastmodified":1582358300,
     "wof:name":"Metlika",
     "wof:parent_id":1108959909,
     "wof:placetype":"locality",

--- a/data/101/845/265/101845265.geojson
+++ b/data/101/845/265/101845265.geojson
@@ -98,6 +98,9 @@
         "wk:page":"Dekani"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"96e9c5748f6d7efd85cb30d72c4a3686",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644982,
+    "wof:lastmodified":1582358300,
     "wof:name":"Dekani",
     "wof:parent_id":1108959527,
     "wof:placetype":"locality",

--- a/data/101/845/271/101845271.geojson
+++ b/data/101/845/271/101845271.geojson
@@ -174,6 +174,9 @@
         "wk:page":"Cerknica"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"438c75236a6342ea0be36d2507a2ee46",
     "wof:hierarchy":[
         {
@@ -188,7 +191,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644982,
+    "wof:lastmodified":1582358300,
     "wof:name":"Cerknica",
     "wof:parent_id":1108959905,
     "wof:placetype":"locality",

--- a/data/101/845/273/101845273.geojson
+++ b/data/101/845/273/101845273.geojson
@@ -87,6 +87,9 @@
         "wk:page":"Deskle"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2741aa2f218ec2fe56194a332f70e572",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":101845273,
-    "wof:lastmodified":1566644977,
+    "wof:lastmodified":1582358299,
     "wof:name":"Deskle",
     "wof:parent_id":1108959537,
     "wof:placetype":"locality",

--- a/data/101/845/277/101845277.geojson
+++ b/data/101/845/277/101845277.geojson
@@ -209,6 +209,9 @@
         "qs_pg:id":1060366
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9a1ca2d9db1273206aa52987cdcdc6c9",
     "wof:hierarchy":[
         {
@@ -220,7 +223,7 @@
         }
     ],
     "wof:id":101845277,
-    "wof:lastmodified":1566644981,
+    "wof:lastmodified":1582358300,
     "wof:name":"Roga\u0161ka Slatina",
     "wof:parent_id":1108959803,
     "wof:placetype":"locality",

--- a/data/101/845/279/101845279.geojson
+++ b/data/101/845/279/101845279.geojson
@@ -97,6 +97,9 @@
         "wd:id":"Q4489175"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"de39238f669f1fe0b57fad3e68034205",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644981,
+    "wof:lastmodified":1582358300,
     "wof:name":"\u0160marje pri Jel\u0161ah",
     "wof:parent_id":1108959607,
     "wof:placetype":"locality",

--- a/data/101/845/281/101845281.geojson
+++ b/data/101/845/281/101845281.geojson
@@ -141,6 +141,9 @@
         "wk:page":"La\u0161ko"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8a73e11e7e99b6ea43be1083b23a01f5",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
         }
     ],
     "wof:id":101845281,
-    "wof:lastmodified":1566644977,
+    "wof:lastmodified":1582358300,
     "wof:name":"La\u0161ko",
     "wof:parent_id":1108959879,
     "wof:placetype":"locality",

--- a/data/101/845/285/101845285.geojson
+++ b/data/101/845/285/101845285.geojson
@@ -138,6 +138,9 @@
         "wk:page":"Lenart v Slovenskih Goricah"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b5021c38a7547bfb566976d6ef7c28cf",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":101845285,
-    "wof:lastmodified":1566644982,
+    "wof:lastmodified":1582358300,
     "wof:name":"Lenart v Slov. goricah",
     "wof:parent_id":1108959477,
     "wof:placetype":"locality",

--- a/data/101/845/289/101845289.geojson
+++ b/data/101/845/289/101845289.geojson
@@ -115,6 +115,9 @@
         "qs_pg:id":1043930
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"30f095824dc42926aa2d7bfaa104aee4",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":101845289,
-    "wof:lastmodified":1566644977,
+    "wof:lastmodified":1582358299,
     "wof:name":"\u0160entilj v Slov. goricah",
     "wof:parent_id":1108959565,
     "wof:placetype":"locality",

--- a/data/101/845/291/101845291.geojson
+++ b/data/101/845/291/101845291.geojson
@@ -120,6 +120,9 @@
         "qs_pg:id":1044003
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"abf4b8325dcbf9cc54c6ec63816a7bed",
     "wof:hierarchy":[
         {
@@ -131,7 +134,7 @@
         }
     ],
     "wof:id":101845291,
-    "wof:lastmodified":1566644982,
+    "wof:lastmodified":1582358300,
     "wof:name":"Oplotnica",
     "wof:parent_id":1108959737,
     "wof:placetype":"locality",

--- a/data/101/845/293/101845293.geojson
+++ b/data/101/845/293/101845293.geojson
@@ -107,6 +107,9 @@
         "wk:page":"Prebold"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"13536250e03540096f722d2d82251fd6",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
         }
     ],
     "wof:id":101845293,
-    "wof:lastmodified":1566644978,
+    "wof:lastmodified":1582358300,
     "wof:name":"Prebold",
     "wof:parent_id":1108959713,
     "wof:placetype":"locality",

--- a/data/101/845/295/101845295.geojson
+++ b/data/101/845/295/101845295.geojson
@@ -135,6 +135,9 @@
         "wk:page":"Polzela"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ae46720020ba24057d4eac74c08b3605",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":101845295,
-    "wof:lastmodified":1566644978,
+    "wof:lastmodified":1582358300,
     "wof:name":"Polzela",
     "wof:parent_id":1108959635,
     "wof:placetype":"locality",

--- a/data/101/845/297/101845297.geojson
+++ b/data/101/845/297/101845297.geojson
@@ -165,6 +165,9 @@
         "wd:id":"Q15867"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"19a34e90891aaab077ca461cfa6056d2",
     "wof:hierarchy":[
         {
@@ -179,7 +182,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644982,
+    "wof:lastmodified":1582358300,
     "wof:name":"Dravograd",
     "wof:parent_id":1108959495,
     "wof:placetype":"locality",

--- a/data/101/845/299/101845299.geojson
+++ b/data/101/845/299/101845299.geojson
@@ -175,6 +175,9 @@
         "wd:id":"Q14468504"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5cb378b87449ee0ee26cef5e35ee5500",
     "wof:hierarchy":[
         {
@@ -186,7 +189,7 @@
         }
     ],
     "wof:id":101845299,
-    "wof:lastmodified":1566644983,
+    "wof:lastmodified":1582358300,
     "wof:name":"Trzin",
     "wof:parent_id":1108959509,
     "wof:placetype":"locality",

--- a/data/101/845/303/101845303.geojson
+++ b/data/101/845/303/101845303.geojson
@@ -98,6 +98,9 @@
         "wk:page":"\u017delezniki"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9e40bd96c86f86b24c78f3b1bae1f869",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":101845303,
-    "wof:lastmodified":1566644980,
+    "wof:lastmodified":1582358300,
     "wof:name":"\u017delezniki",
     "wof:parent_id":1108959701,
     "wof:placetype":"locality",

--- a/data/101/845/307/101845307.geojson
+++ b/data/101/845/307/101845307.geojson
@@ -98,6 +98,9 @@
         "wd:id":"Q2638131"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"90e52818867541b4889c3edaec7fd9a5",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":101845307,
-    "wof:lastmodified":1566644975,
+    "wof:lastmodified":1582358299,
     "wof:name":"Tr\u017ei\u010d",
     "wof:parent_id":1108959917,
     "wof:placetype":"locality",

--- a/data/101/845/311/101845311.geojson
+++ b/data/101/845/311/101845311.geojson
@@ -152,6 +152,9 @@
         "qs_pg:id":1078926
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b3d78db20c3af2ab06832aa17fb86146",
     "wof:hierarchy":[
         {
@@ -163,7 +166,7 @@
         }
     ],
     "wof:id":101845311,
-    "wof:lastmodified":1566644983,
+    "wof:lastmodified":1582358300,
     "wof:name":"Kranjska Gora",
     "wof:parent_id":1108959843,
     "wof:placetype":"locality",

--- a/data/101/845/313/101845313.geojson
+++ b/data/101/845/313/101845313.geojson
@@ -179,6 +179,9 @@
         "qs_pg:id":1060360
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1965ac51eb9605790d318184d806c304",
     "wof:hierarchy":[
         {
@@ -190,7 +193,7 @@
         }
     ],
     "wof:id":101845313,
-    "wof:lastmodified":1566644979,
+    "wof:lastmodified":1582358300,
     "wof:name":"Bovec",
     "wof:parent_id":1108959541,
     "wof:placetype":"locality",

--- a/data/101/845/321/101845321.geojson
+++ b/data/101/845/321/101845321.geojson
@@ -190,6 +190,9 @@
         "wk:page":"Bre\u017eice"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"72311bf2eecf85a3be8634698e0eb81e",
     "wof:hierarchy":[
         {
@@ -204,7 +207,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644984,
+    "wof:lastmodified":1582358300,
     "wof:name":"Bre\u017eice",
     "wof:parent_id":1108959585,
     "wof:placetype":"locality",

--- a/data/101/845/333/101845333.geojson
+++ b/data/101/845/333/101845333.geojson
@@ -177,6 +177,9 @@
         "wd:id":"Q438"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7979e1d259471655c42d3693e1a77f32",
     "wof:hierarchy":[
         {
@@ -191,7 +194,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644980,
+    "wof:lastmodified":1582358300,
     "wof:name":"Vrhnika",
     "wof:parent_id":1108959851,
     "wof:placetype":"locality",

--- a/data/101/845/335/101845335.geojson
+++ b/data/101/845/335/101845335.geojson
@@ -347,6 +347,9 @@
         "wd:id":"Q15875"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4baa506d4c573297aae9cd144f692595",
     "wof:hierarchy":[
         {
@@ -361,7 +364,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644980,
+    "wof:lastmodified":1582358300,
     "wof:name":"Idrija",
     "wof:parent_id":1108959535,
     "wof:placetype":"locality",

--- a/data/101/845/339/101845339.geojson
+++ b/data/101/845/339/101845339.geojson
@@ -98,6 +98,9 @@
         "wk:page":"Ver\u017eej"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"76c44cac40575632a52b9be12ca2cc14",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":101845339,
-    "wof:lastmodified":1566644976,
+    "wof:lastmodified":1582358299,
     "wof:name":"Ver\u017eej",
     "wof:parent_id":1108959771,
     "wof:placetype":"locality",

--- a/data/101/845/357/101845357.geojson
+++ b/data/101/845/357/101845357.geojson
@@ -190,6 +190,9 @@
         "wd:id":"Q1809612"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0775178bf25cbe8cf066337ad0205aa9",
     "wof:hierarchy":[
         {
@@ -201,7 +204,7 @@
         }
     ],
     "wof:id":101845357,
-    "wof:lastmodified":1566644980,
+    "wof:lastmodified":1582358300,
     "wof:name":"Vitanje",
     "wof:parent_id":1108959681,
     "wof:placetype":"locality",

--- a/data/101/845/365/101845365.geojson
+++ b/data/101/845/365/101845365.geojson
@@ -118,6 +118,9 @@
         "qs_pg:id":226840
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2071da3ca109edd503e16d408aa09f1e",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":101845365,
-    "wof:lastmodified":1566644976,
+    "wof:lastmodified":1582358299,
     "wof:name":"Lukovica pri Dom\u017ealah",
     "wof:parent_id":1108959807,
     "wof:placetype":"locality",

--- a/data/101/845/367/101845367.geojson
+++ b/data/101/845/367/101845367.geojson
@@ -82,6 +82,9 @@
         "wd:id":"Q644115"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"967d4902ca56a0f8ffc8588c03ad8bc8",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
         }
     ],
     "wof:id":101845367,
-    "wof:lastmodified":1566644980,
+    "wof:lastmodified":1582358300,
     "wof:name":"Morav\u010de",
     "wof:parent_id":1108959515,
     "wof:placetype":"locality",

--- a/data/101/853/161/101853161.geojson
+++ b/data/101/853/161/101853161.geojson
@@ -88,6 +88,9 @@
         "wk:page":"Bukovica, Ren\u010de\u2013Vogrsko"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e6705dc06fd7599171066066fdcd12e5",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":101853161,
-    "wof:lastmodified":1566645007,
+    "wof:lastmodified":1582358304,
     "wof:name":"Bukovica",
     "wof:parent_id":1108959733,
     "wof:placetype":"locality",

--- a/data/101/853/163/101853163.geojson
+++ b/data/101/853/163/101853163.geojson
@@ -134,6 +134,10 @@
         "qs_pg:id":1044042
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"1e863a8eb5b1332c574648faf248fe0d",
     "wof:hierarchy":[
         {
@@ -145,7 +149,7 @@
         }
     ],
     "wof:id":101853163,
-    "wof:lastmodified":1566645007,
+    "wof:lastmodified":1582358304,
     "wof:name":"Kanal",
     "wof:parent_id":1108959537,
     "wof:placetype":"locality",

--- a/data/101/857/885/101857885.geojson
+++ b/data/101/857/885/101857885.geojson
@@ -115,6 +115,9 @@
         "wk:page":"\u0160entrupert"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f509cd25ebc8e9422045044bf429812a",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":101857885,
-    "wof:lastmodified":1566644987,
+    "wof:lastmodified":1582358301,
     "wof:name":"\u0160entrupert",
     "wof:parent_id":1108959841,
     "wof:placetype":"locality",

--- a/data/101/857/889/101857889.geojson
+++ b/data/101/857/889/101857889.geojson
@@ -115,6 +115,9 @@
         "wd:id":"Q323375"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c5b8246dd7a9b52216c1c332821bcdbb",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":101857889,
-    "wof:lastmodified":1566644986,
+    "wof:lastmodified":1582358301,
     "wof:name":"\u0160marje\u0161ke Toplice",
     "wof:parent_id":1108959833,
     "wof:placetype":"locality",

--- a/data/101/857/891/101857891.geojson
+++ b/data/101/857/891/101857891.geojson
@@ -90,6 +90,9 @@
         "wd:id":"Q1618559"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"827613872c19be20e927724fe4a80525",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":101857891,
-    "wof:lastmodified":1566644987,
+    "wof:lastmodified":1582358301,
     "wof:name":"Sv. Anton",
     "wof:parent_id":1108959527,
     "wof:placetype":"locality",

--- a/data/101/857/893/101857893.geojson
+++ b/data/101/857/893/101857893.geojson
@@ -118,6 +118,10 @@
         "qs_pg:id":265207
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"420fcee9ada2f17f3ad35f614723da31",
     "wof:hierarchy":[
         {
@@ -129,7 +133,7 @@
         }
     ],
     "wof:id":101857893,
-    "wof:lastmodified":1566644986,
+    "wof:lastmodified":1582358301,
     "wof:name":"Brezovica pri Ljubljani",
     "wof:parent_id":1108959895,
     "wof:placetype":"locality",

--- a/data/101/857/895/101857895.geojson
+++ b/data/101/857/895/101857895.geojson
@@ -91,6 +91,10 @@
         "wk:page":"Spodnja Idrija"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"dd01e971c565d59111da5a6cbefb0d3e",
     "wof:hierarchy":[
         {
@@ -105,7 +109,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644986,
+    "wof:lastmodified":1582358301,
     "wof:name":"Spodnja Idrija",
     "wof:parent_id":1108959535,
     "wof:placetype":"locality",

--- a/data/101/857/897/101857897.geojson
+++ b/data/101/857/897/101857897.geojson
@@ -93,6 +93,9 @@
         "wk:page":"Rogatec"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7d7702dcbd3c98cdc2b67e22efcf56bd",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":101857897,
-    "wof:lastmodified":1566644987,
+    "wof:lastmodified":1582358301,
     "wof:name":"Rogatec",
     "wof:parent_id":1108959609,
     "wof:placetype":"locality",

--- a/data/101/857/899/101857899.geojson
+++ b/data/101/857/899/101857899.geojson
@@ -94,6 +94,9 @@
         "wk:page":"Dobje pri Planini"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d46164ef50906d07c4533543d6adc9c0",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":101857899,
-    "wof:lastmodified":1566644987,
+    "wof:lastmodified":1582358301,
     "wof:name":"Dobje pri Planini",
     "wof:parent_id":1108959685,
     "wof:placetype":"locality",

--- a/data/101/857/901/101857901.geojson
+++ b/data/101/857/901/101857901.geojson
@@ -117,6 +117,9 @@
         "wk:page":"\u017detale"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"86054f16a6df15df883d47017d2f4661",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":101857901,
-    "wof:lastmodified":1566644986,
+    "wof:lastmodified":1582358301,
     "wof:name":"\u017detale",
     "wof:parent_id":1108959767,
     "wof:placetype":"locality",

--- a/data/101/857/903/101857903.geojson
+++ b/data/101/857/903/101857903.geojson
@@ -102,6 +102,9 @@
         "wk:page":"Mirna Pe\u010d"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d36029d3221cba877a96ed2446179611",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":101857903,
-    "wof:lastmodified":1566644987,
+    "wof:lastmodified":1582358301,
     "wof:name":"Mirna Pe\u010d",
     "wof:parent_id":1108959751,
     "wof:placetype":"locality",

--- a/data/101/857/907/101857907.geojson
+++ b/data/101/857/907/101857907.geojson
@@ -147,6 +147,9 @@
         "wk:page":"Bistrica ob Sotli"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"325305ae631aebeda3c049a130235c37",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
         }
     ],
     "wof:id":101857907,
-    "wof:lastmodified":1566644986,
+    "wof:lastmodified":1582358301,
     "wof:name":"Bistrica ob Sotli",
     "wof:parent_id":1108959915,
     "wof:placetype":"locality",

--- a/data/101/857/909/101857909.geojson
+++ b/data/101/857/909/101857909.geojson
@@ -93,6 +93,9 @@
         "wd:id":"Q3503224"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d1bb96e9949dd4e28adc1696cf5e0caa",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":101857909,
-    "wof:lastmodified":1566644986,
+    "wof:lastmodified":1582358301,
     "wof:name":"Osilnica",
     "wof:parent_id":1108959563,
     "wof:placetype":"locality",

--- a/data/101/857/911/101857911.geojson
+++ b/data/101/857/911/101857911.geojson
@@ -100,6 +100,9 @@
         "wk:page":"Hrib\u2013Lo\u0161ki Potok"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0cae626b3dbfc1548f660d9b44ccc8b0",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":101857911,
-    "wof:lastmodified":1566644988,
+    "wof:lastmodified":1582358301,
     "wof:name":"Hrib-Lo\u0161ki Potok",
     "wof:parent_id":1108959513,
     "wof:placetype":"locality",

--- a/data/101/857/913/101857913.geojson
+++ b/data/101/857/913/101857913.geojson
@@ -124,6 +124,10 @@
         "qs_pg:id":1076007
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"be334180ffaa9b6c9c318401a530f4ee",
     "wof:hierarchy":[
         {
@@ -135,7 +139,7 @@
         }
     ],
     "wof:id":101857913,
-    "wof:lastmodified":1566644987,
+    "wof:lastmodified":1582358301,
     "wof:name":"Pod\u010detrtek",
     "wof:parent_id":1108959649,
     "wof:placetype":"locality",

--- a/data/101/857/915/101857915.geojson
+++ b/data/101/857/915/101857915.geojson
@@ -186,6 +186,9 @@
         "wk:page":"Vransko"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1ab57e7178a8eb5f40b2d4c4406732cc",
     "wof:hierarchy":[
         {
@@ -197,7 +200,7 @@
         }
     ],
     "wof:id":101857915,
-    "wof:lastmodified":1566644987,
+    "wof:lastmodified":1582358301,
     "wof:name":"Vransko",
     "wof:parent_id":1108959827,
     "wof:placetype":"locality",

--- a/data/101/858/959/101858959.geojson
+++ b/data/101/858/959/101858959.geojson
@@ -85,6 +85,9 @@
         "wk:page":"Sveti Toma\u017e, Sveti Toma\u017e"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cb27d0aea7e371e83133c30f46417dfe",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":101858959,
-    "wof:lastmodified":1566644992,
+    "wof:lastmodified":1582358302,
     "wof:name":"Sveti Toma\u017e",
     "wof:parent_id":1108959931,
     "wof:placetype":"locality",

--- a/data/101/858/961/101858961.geojson
+++ b/data/101/858/961/101858961.geojson
@@ -97,6 +97,9 @@
         "wk:page":"Vitomarci"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7f915aec49f9bc714a459b1707b7267f",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":101858961,
-    "wof:lastmodified":1566644992,
+    "wof:lastmodified":1582358302,
     "wof:name":"Vitomarci",
     "wof:parent_id":1108959627,
     "wof:placetype":"locality",

--- a/data/101/858/963/101858963.geojson
+++ b/data/101/858/963/101858963.geojson
@@ -115,6 +115,9 @@
         "wk:page":"Makole"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"310949234ebdb76d75229d6308ca67e3",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":101858963,
-    "wof:lastmodified":1566644991,
+    "wof:lastmodified":1582358302,
     "wof:name":"Makole",
     "wof:parent_id":1108959773,
     "wof:placetype":"locality",

--- a/data/101/858/965/101858965.geojson
+++ b/data/101/858/965/101858965.geojson
@@ -254,6 +254,9 @@
         "wk:page":"Zgornje Gorje"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7d14e9887d93737356e91746e55bbfe4",
     "wof:hierarchy":[
         {
@@ -265,7 +268,7 @@
         }
     ],
     "wof:id":101858965,
-    "wof:lastmodified":1566644991,
+    "wof:lastmodified":1582358301,
     "wof:name":"Zgornje Gorje",
     "wof:parent_id":1108959735,
     "wof:placetype":"locality",

--- a/data/101/858/969/101858969.geojson
+++ b/data/101/858/969/101858969.geojson
@@ -102,6 +102,9 @@
         "wk:page":"Maj\u0161perk"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aff5c7c1b0b260951b6a7a477df43df3",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":101858969,
-    "wof:lastmodified":1566644993,
+    "wof:lastmodified":1582358302,
     "wof:name":"Maj\u0161perk",
     "wof:parent_id":1108959491,
     "wof:placetype":"locality",

--- a/data/101/858/971/101858971.geojson
+++ b/data/101/858/971/101858971.geojson
@@ -101,6 +101,9 @@
         "wk:page":"Golnik"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"04e8a2bb72d0ef9c9e0e29e4db3ca10c",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644992,
+    "wof:lastmodified":1582358302,
     "wof:name":"Golnik",
     "wof:parent_id":1108959933,
     "wof:placetype":"locality",

--- a/data/101/858/973/101858973.geojson
+++ b/data/101/858/973/101858973.geojson
@@ -127,6 +127,9 @@
         "qs_pg:id":977062
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8afcca25a79ed27c0be9ea964b4c8e27",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":101858973,
-    "wof:lastmodified":1566644993,
+    "wof:lastmodified":1582358302,
     "wof:name":"Destrnik",
     "wof:parent_id":1108959755,
     "wof:placetype":"locality",

--- a/data/101/858/975/101858975.geojson
+++ b/data/101/858/975/101858975.geojson
@@ -266,6 +266,9 @@
         "wk:page":"Santa Ana, El Salvador"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d917c26ae11a9272ee79229b7f771a4b",
     "wof:hierarchy":[
         {
@@ -277,7 +280,7 @@
         }
     ],
     "wof:id":101858975,
-    "wof:lastmodified":1566644993,
+    "wof:lastmodified":1582358302,
     "wof:name":"Sv. Ana v Slov. goricah",
     "wof:parent_id":1108959709,
     "wof:placetype":"locality",

--- a/data/101/858/977/101858977.geojson
+++ b/data/101/858/977/101858977.geojson
@@ -177,6 +177,9 @@
         "wk:page":"Podlehnik"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"455c3ee33a973bbeeb37ef9438aa8113",
     "wof:hierarchy":[
         {
@@ -188,7 +191,7 @@
         }
     ],
     "wof:id":101858977,
-    "wof:lastmodified":1566644991,
+    "wof:lastmodified":1582358302,
     "wof:name":"Podlehnik",
     "wof:parent_id":1108959757,
     "wof:placetype":"locality",

--- a/data/101/858/979/101858979.geojson
+++ b/data/101/858/979/101858979.geojson
@@ -128,6 +128,9 @@
         "wd:id":"Q511695"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1d09f4b54d6896c19fe4664eb2f2cf2a",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":101858979,
-    "wof:lastmodified":1566644992,
+    "wof:lastmodified":1582358302,
     "wof:name":"Cerkvenjak",
     "wof:parent_id":1108959703,
     "wof:placetype":"locality",

--- a/data/101/858/981/101858981.geojson
+++ b/data/101/858/981/101858981.geojson
@@ -130,6 +130,9 @@
         "wk:page":"Zgornje Jezersko"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"59c613021e5817e4afe8ff047ce6dc0e",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":101858981,
-    "wof:lastmodified":1566644993,
+    "wof:lastmodified":1582358302,
     "wof:name":"Zgornje Jezersko",
     "wof:parent_id":1108959625,
     "wof:placetype":"locality",

--- a/data/101/858/983/101858983.geojson
+++ b/data/101/858/983/101858983.geojson
@@ -105,6 +105,9 @@
         "wk:page":"Zavr\u010d"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"48a808f5125bd3ff54b7cbed85e17e36",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
         }
     ],
     "wof:id":101858983,
-    "wof:lastmodified":1566644992,
+    "wof:lastmodified":1582358302,
     "wof:name":"Zavr\u010d",
     "wof:parent_id":1108959619,
     "wof:placetype":"locality",

--- a/data/101/858/987/101858987.geojson
+++ b/data/101/858/987/101858987.geojson
@@ -166,6 +166,9 @@
         "wd:id":"Q920353"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b15377b3f72a5e53ede97dc851b4b267",
     "wof:hierarchy":[
         {
@@ -177,7 +180,7 @@
         }
     ],
     "wof:id":101858987,
-    "wof:lastmodified":1566644993,
+    "wof:lastmodified":1582358302,
     "wof:name":"Sveti Jurij ob \u0160\u010davnici",
     "wof:parent_id":1108959591,
     "wof:placetype":"locality",

--- a/data/101/858/989/101858989.geojson
+++ b/data/101/858/989/101858989.geojson
@@ -97,6 +97,9 @@
         "wk:page":"Kruplivnik"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"622e207c9d761109592c07a58d3c4b60",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":101858989,
-    "wof:lastmodified":1566644993,
+    "wof:lastmodified":1582358302,
     "wof:name":"Grad",
     "wof:parent_id":1108959663,
     "wof:placetype":"locality",

--- a/data/101/858/991/101858991.geojson
+++ b/data/101/858/991/101858991.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Gornji Petrovci"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"68eefa31a5d532e456daf39fe8bbbb54",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":101858991,
-    "wof:lastmodified":1566644991,
+    "wof:lastmodified":1582358301,
     "wof:name":"Gornji Petrovci",
     "wof:parent_id":1108959531,
     "wof:placetype":"locality",

--- a/data/101/858/993/101858993.geojson
+++ b/data/101/858/993/101858993.geojson
@@ -103,6 +103,9 @@
         "wk:page":"Kuzma, Kuzma"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"216902475564ddeaab95898ffc4dc399",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":101858993,
-    "wof:lastmodified":1566644992,
+    "wof:lastmodified":1582358302,
     "wof:name":"Kuzma",
     "wof:parent_id":1108959511,
     "wof:placetype":"locality",

--- a/data/101/858/995/101858995.geojson
+++ b/data/101/858/995/101858995.geojson
@@ -84,6 +84,9 @@
         "wd:id":"Q2643657"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e84dd83e6b78c491e65950481e4c775c",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":101858995,
-    "wof:lastmodified":1566644992,
+    "wof:lastmodified":1582358302,
     "wof:name":"Jurovski Dol",
     "wof:parent_id":1108959815,
     "wof:placetype":"locality",

--- a/data/101/858/997/101858997.geojson
+++ b/data/101/858/997/101858997.geojson
@@ -180,6 +180,9 @@
         "wk:page":"Jur\u0161inci"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d0b328a3ba84ef8580a493700db1a1df",
     "wof:hierarchy":[
         {
@@ -191,7 +194,7 @@
         }
     ],
     "wof:id":101858997,
-    "wof:lastmodified":1566644991,
+    "wof:lastmodified":1582358302,
     "wof:name":"Jur\u0161inci",
     "wof:parent_id":1108959781,
     "wof:placetype":"locality",

--- a/data/101/858/999/101858999.geojson
+++ b/data/101/858/999/101858999.geojson
@@ -99,6 +99,9 @@
         "wk:page":"Trnovska Vas"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"65c781a8a26e252123c7ceb147e5a0f8",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":101858999,
-    "wof:lastmodified":1566644991,
+    "wof:lastmodified":1582358302,
     "wof:name":"Trnovska vas",
     "wof:parent_id":1108959717,
     "wof:placetype":"locality",

--- a/data/101/859/001/101859001.geojson
+++ b/data/101/859/001/101859001.geojson
@@ -98,6 +98,10 @@
         "wk:page":"Pesnica pri Mariboru"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"2df16d611712a346782fc21dc5e4fd42",
     "wof:hierarchy":[
         {
@@ -112,7 +116,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644985,
+    "wof:lastmodified":1582358300,
     "wof:name":"Pesnica pri Mariboru",
     "wof:parent_id":1108959553,
     "wof:placetype":"locality",

--- a/data/101/859/005/101859005.geojson
+++ b/data/101/859/005/101859005.geojson
@@ -152,6 +152,10 @@
         "qs_pg:id":517487
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"c1a66feebf87cafdc55876271ca74ce3",
     "wof:hierarchy":[
         {
@@ -163,7 +167,7 @@
         }
     ],
     "wof:id":101859005,
-    "wof:lastmodified":1566644985,
+    "wof:lastmodified":1582358301,
     "wof:name":"Ribnica na Pohorju",
     "wof:parent_id":1108959769,
     "wof:placetype":"locality",

--- a/data/101/859/007/101859007.geojson
+++ b/data/101/859/007/101859007.geojson
@@ -94,6 +94,9 @@
         "wk:page":"Lu\u010de"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ae982c1c5cdb163d697c8d85f22a15ba",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":101859007,
-    "wof:lastmodified":1566644985,
+    "wof:lastmodified":1582358300,
     "wof:name":"Lu\u010de",
     "wof:parent_id":1108959505,
     "wof:placetype":"locality",

--- a/data/101/859/009/101859009.geojson
+++ b/data/101/859/009/101859009.geojson
@@ -192,6 +192,9 @@
         "wk:page":"Sol\u010dava"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0103e786b5fcec2ddf1ef7f1ab9cb838",
     "wof:hierarchy":[
         {
@@ -203,7 +206,7 @@
         }
     ],
     "wof:id":101859009,
-    "wof:lastmodified":1566644985,
+    "wof:lastmodified":1582358300,
     "wof:name":"Sol\u010dava",
     "wof:parent_id":1108959639,
     "wof:placetype":"locality",

--- a/data/101/859/011/101859011.geojson
+++ b/data/101/859/011/101859011.geojson
@@ -133,6 +133,9 @@
         "wk:page":"Hodo\u0161"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d9341b453ec50908ecd3696be09a6a27",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":101859011,
-    "wof:lastmodified":1566644985,
+    "wof:lastmodified":1582358300,
     "wof:name":"Hodo\u0161",
     "wof:parent_id":1108959637,
     "wof:placetype":"locality",

--- a/data/101/859/013/101859013.geojson
+++ b/data/101/859/013/101859013.geojson
@@ -85,6 +85,9 @@
         "wk:page":"Spodnji Duplek"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cc69ad4b32a5a7f7f8afbda5923a8c4b",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":101859013,
-    "wof:lastmodified":1566644985,
+    "wof:lastmodified":1582358300,
     "wof:name":"Spodnji Duplek",
     "wof:parent_id":1108959529,
     "wof:placetype":"locality",

--- a/data/101/859/015/101859015.geojson
+++ b/data/101/859/015/101859015.geojson
@@ -122,6 +122,9 @@
         "wd:id":"Q340205"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"07b0d3f0846e99c456e5e43fa214be8b",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":101859015,
-    "wof:lastmodified":1566644985,
+    "wof:lastmodified":1582358300,
     "wof:name":"Cirkulane",
     "wof:parent_id":1108959743,
     "wof:placetype":"locality",

--- a/data/101/875/845/101875845.geojson
+++ b/data/101/875/845/101875845.geojson
@@ -100,6 +100,9 @@
         "wk:page":"Hru\u0161ica, Jesenice"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"faecd0c8880b1c69c41d38615ed29432",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":101875845,
-    "wof:lastmodified":1566644984,
+    "wof:lastmodified":1582358300,
     "wof:name":"Hru\u0161ica",
     "wof:parent_id":1108959875,
     "wof:placetype":"locality",

--- a/data/101/875/847/101875847.geojson
+++ b/data/101/875/847/101875847.geojson
@@ -84,6 +84,10 @@
         "wd:id":"Q2671086"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"21299524e966d7f1af31e037be748505",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
         }
     ],
     "wof:id":101875847,
-    "wof:lastmodified":1566644984,
+    "wof:lastmodified":1582358300,
     "wof:name":"Vuzenica",
     "wof:parent_id":1108959677,
     "wof:placetype":"locality",

--- a/data/101/910/939/101910939.geojson
+++ b/data/101/910/939/101910939.geojson
@@ -48,6 +48,9 @@
         "qs_pg:id":1078929
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5a4d9015f3aa6632497bd63874cfe93c",
     "wof:hierarchy":[
         {
@@ -59,7 +62,7 @@
         }
     ],
     "wof:id":101910939,
-    "wof:lastmodified":1566645007,
+    "wof:lastmodified":1582358304,
     "wof:name":"\u00c5 Tanjel",
     "wof:parent_id":1108959539,
     "wof:placetype":"locality",

--- a/data/856/337/79/85633779.geojson
+++ b/data/856/337/79/85633779.geojson
@@ -1069,6 +1069,10 @@
     },
     "wof:country":"SI",
     "wof:country_alpha3":"SVN",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"5794d7a401837908eb746fd4c598c4e2",
     "wof:hierarchy":[
         {
@@ -1083,7 +1087,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1566644465,
+    "wof:lastmodified":1582358283,
     "wof:name":"Slovenia",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/858/982/11/85898211.geojson
+++ b/data/858/982/11/85898211.geojson
@@ -96,6 +96,9 @@
         "wk:page":"\u010crnu\u010de District"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"19c975ee3438fd8a88bc5e9952418bba",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644476,
+    "wof:lastmodified":1582358284,
     "wof:name":"Crnuce",
     "wof:parent_id":101752073,
     "wof:placetype":"neighbourhood",

--- a/data/858/982/15/85898215.geojson
+++ b/data/858/982/15/85898215.geojson
@@ -195,6 +195,10 @@
         "wd:id":"Q946033"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"1b76373eb776c5fcbdd90b8f007d5fc4",
     "wof:hierarchy":[
         {
@@ -210,7 +214,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644476,
+    "wof:lastmodified":1582358285,
     "wof:name":"Polje",
     "wof:parent_id":101752073,
     "wof:placetype":"neighbourhood",

--- a/data/858/982/17/85898217.geojson
+++ b/data/858/982/17/85898217.geojson
@@ -100,6 +100,10 @@
         "qs_pg:id":1117128
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"85151e0af531e56f242de12246597b91",
     "wof:hierarchy":[
         {
@@ -115,7 +119,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644476,
+    "wof:lastmodified":1582358284,
     "wof:name":"Sentvid",
     "wof:parent_id":101752073,
     "wof:placetype":"neighbourhood",

--- a/data/858/982/21/85898221.geojson
+++ b/data/858/982/21/85898221.geojson
@@ -197,6 +197,10 @@
         "qs_pg:id":290698
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"68f61e3186296813418749d5e3164b34",
     "wof:hierarchy":[
         {
@@ -212,7 +216,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644476,
+    "wof:lastmodified":1582358285,
     "wof:name":"Vic",
     "wof:parent_id":101752073,
     "wof:placetype":"neighbourhood",

--- a/data/858/985/79/85898579.geojson
+++ b/data/858/985/79/85898579.geojson
@@ -90,6 +90,9 @@
         "qs_pg:id":1062914
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"623c3c3d53294ad3959b7c599262e53a",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
     "wof:lang":[
         "ger"
     ],
-    "wof:lastmodified":1566644476,
+    "wof:lastmodified":1582358284,
     "wof:name":"St. Peter",
     "wof:parent_id":101748063,
     "wof:placetype":"neighbourhood",

--- a/data/859/297/45/85929745.geojson
+++ b/data/859/297/45/85929745.geojson
@@ -113,6 +113,10 @@
         "wk:page":"Trnovo, Nova Gorica"
     },
     "wof:country":"SI",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"b8e7bd3e048b1e195a56a91bfc31f30b",
     "wof:hierarchy":[
         {
@@ -128,7 +132,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566644465,
+    "wof:lastmodified":1582358282,
     "wof:name":"Trnovo",
     "wof:parent_id":101752073,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.