### PR TITLE
Name updates

### DIFF
--- a/data/110/894/323/7/1108943237.geojson
+++ b/data/110/894/323/7/1108943237.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"14.4163799545,46.0844044758,14.4163799545,46.0844044758",
+    "geom:bbox":"14.41638,46.084404,14.41638,46.084404",
     "geom:latitude":46.084404,
     "geom:longitude":14.41638,
     "iso:country":"SI",
@@ -29,15 +29,15 @@
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
         102191581,
-        1108959501,
         85633779,
+        1108959501,
         1108959949
     ],
     "wof:breaches":[],
     "wof:concordances":{},
     "wof:country":"SI",
     "wof:created":1491363617,
-    "wof:geomhash":"f4e22af7043634d4c327953256412b21",
+    "wof:geomhash":"c0c7a9a19b32e3bbe447bfe906c7c48a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -49,8 +49,8 @@
         }
     ],
     "wof:id":1108943237,
-    "wof:lastmodified":1566644885,
-    "wof:name":"Tosko Celo\n",
+    "wof:lastmodified":1587164336,
+    "wof:name":"Tosko Celo",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-si",
@@ -59,10 +59,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    14.41637995451152,
-    46.08440447577247,
-    14.41637995451152,
-    46.08440447577247
+    14.41638,
+    46.084404,
+    14.41638,
+    46.084404
 ],
-  "geometry": {"coordinates":[14.41637995451152,46.08440447577247],"type":"Point"}
+  "geometry": {"coordinates":[14.41638,46.084404],"type":"Point"}
 }

--- a/data/110/894/324/9/1108943249.geojson
+++ b/data/110/894/324/9/1108943249.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"14.5505619983,46.0429943488,14.5505619983,46.0429943488",
+    "geom:bbox":"14.550562,46.042994,14.550562,46.042994",
     "geom:latitude":46.042994,
     "geom:longitude":14.550562,
     "iso:country":"SI",
@@ -29,8 +29,8 @@
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
         102191581,
-        1108959501,
         85633779,
+        1108959501,
         101752073,
         1108959949
     ],
@@ -38,7 +38,7 @@
     "wof:concordances":{},
     "wof:country":"SI",
     "wof:created":1491363623,
-    "wof:geomhash":"cbe4342f79559b36fcb0bd613d389f58",
+    "wof:geomhash":"f320f31048249d96249f9d827b2b654c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -50,8 +50,8 @@
         }
     ],
     "wof:id":1108943249,
-    "wof:lastmodified":1566644884,
-    "wof:name":"Zgornja Hrusica\n",
+    "wof:lastmodified":1587164336,
+    "wof:name":"Zgornja Hrusica",
     "wof:parent_id":101752073,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-si",
@@ -60,10 +60,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    14.55056199834381,
-    46.04299434877335,
-    14.55056199834381,
-    46.04299434877335
+    14.550562,
+    46.042994,
+    14.550562,
+    46.042994
 ],
-  "geometry": {"coordinates":[14.55056199834381,46.04299434877335],"type":"Point"}
+  "geometry": {"coordinates":[14.550562,46.042994],"type":"Point"}
 }

--- a/data/110/894/328/5/1108943285.geojson
+++ b/data/110/894/328/5/1108943285.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"14.5925101231,46.0715609095,14.5925101231,46.0715609095",
+    "geom:bbox":"14.59251,46.071561,14.59251,46.071561",
     "geom:latitude":46.071561,
     "geom:longitude":14.59251,
     "iso:country":"SI",
@@ -26,8 +26,8 @@
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
         102191581,
-        1108959501,
         85633779,
+        1108959501,
         101752073,
         1108959949
     ],
@@ -35,7 +35,7 @@
     "wof:concordances":{},
     "wof:country":"SI",
     "wof:created":1491363640,
-    "wof:geomhash":"8bec8b420a7572ffb755e4207c3693dc",
+    "wof:geomhash":"72715e4e12c6006ec6b3c44ee9674d77",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -47,8 +47,8 @@
         }
     ],
     "wof:id":1108943285,
-    "wof:lastmodified":1566644890,
-    "wof:name":"Spodnja Zadobrova\n",
+    "wof:lastmodified":1587164336,
+    "wof:name":"Spodnja Zadobrova",
     "wof:parent_id":101752073,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-si",
@@ -57,10 +57,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    14.59251012309657,
-    46.0715609094934,
-    14.59251012309657,
-    46.0715609094934
+    14.59251,
+    46.071561,
+    14.59251,
+    46.071561
 ],
-  "geometry": {"coordinates":[14.59251012309657,46.0715609094934],"type":"Point"}
+  "geometry": {"coordinates":[14.59251,46.071561],"type":"Point"}
 }

--- a/data/110/894/328/7/1108943287.geojson
+++ b/data/110/894/328/7/1108943287.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"14.5820959943,46.0698142028,14.5820959943,46.0698142028",
+    "geom:bbox":"14.582096,46.069814,14.582096,46.069814",
     "geom:latitude":46.069814,
     "geom:longitude":14.582096,
     "iso:country":"SI",
@@ -26,8 +26,8 @@
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
         102191581,
-        1108959501,
         85633779,
+        1108959501,
         101752073,
         1108959949
     ],
@@ -35,7 +35,7 @@
     "wof:concordances":{},
     "wof:country":"SI",
     "wof:created":1491363641,
-    "wof:geomhash":"4d8f96df6a24b2f34e2d42cb091dc405",
+    "wof:geomhash":"aef61b78b4e2aa81cbd13ef1f7b9dbdf",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -47,8 +47,8 @@
         }
     ],
     "wof:id":1108943287,
-    "wof:lastmodified":1566644890,
-    "wof:name":"Zgornja Zadobrova\n",
+    "wof:lastmodified":1587164336,
+    "wof:name":"Zgornja Zadobrova",
     "wof:parent_id":101752073,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-si",
@@ -57,10 +57,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    14.58209599432153,
-    46.06981420281745,
-    14.58209599432153,
-    46.06981420281745
+    14.582096,
+    46.069814,
+    14.582096,
+    46.069814
 ],
-  "geometry": {"coordinates":[14.58209599432153,46.06981420281745],"type":"Point"}
+  "geometry": {"coordinates":[14.582096,46.069814],"type":"Point"}
 }

--- a/data/110/894/337/3/1108943373.geojson
+++ b/data/110/894/337/3/1108943373.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"14.5469149438,46.109951346,14.5469149438,46.109951346",
+    "geom:bbox":"14.546915,46.109951,14.546915,46.109951",
     "geom:latitude":46.109951,
     "geom:longitude":14.546915,
     "iso:country":"SI",
@@ -29,15 +29,15 @@
     "src:lbl_centroid":"mz",
     "wof:belongsto":[
         102191581,
-        1108959501,
         85633779,
+        1108959501,
         1108959949
     ],
     "wof:breaches":[],
     "wof:concordances":{},
     "wof:country":"SI",
     "wof:created":1491363698,
-    "wof:geomhash":"5478c6eb9e075cdb7dccdfbdf5bf1dfd",
+    "wof:geomhash":"6bed82502025fa99c6852b7e05ea2bff",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -49,8 +49,8 @@
         }
     ],
     "wof:id":1108943373,
-    "wof:lastmodified":1566644884,
-    "wof:name":"Dobrava pri Crnucah\n",
+    "wof:lastmodified":1587164336,
+    "wof:name":"Dobrava pri Crnucah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-si",
@@ -59,10 +59,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    14.54691494376974,
-    46.10995134604129,
-    14.54691494376974,
-    46.10995134604129
+    14.546915,
+    46.109951,
+    14.546915,
+    46.109951
 ],
-  "geometry": {"coordinates":[14.54691494376974,46.10995134604129],"type":"Point"}
+  "geometry": {"coordinates":[14.546915,46.109951],"type":"Point"}
 }


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.