### PR TITLE
SI concordances, placetype local, and more

### DIFF
--- a/data/110/895/946/5/1108959465.geojson
+++ b/data/110/895/946/5/1108959465.geojson
@@ -26,7 +26,10 @@
         "City Municipality of Novo Mesto"
     ],
     "label:eng_x_preferred_placetype":[
-        "city municipality"
+        "urban municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
     ],
     "label:slv_x_preferred_longname":[
         "Mestna ob\u010dina Novo mesto"
@@ -64,8 +67,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_085",
-        "eurostat:nuts_2021_id":"085"
+        "eurostat:nuts_2021_id":"085",
+        "svn-sma:id":"085"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417054,
     "wof:geomhash":"5aa40fcd1c2a8b13f4e95776a89a6ea3",
@@ -84,7 +89,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354760,
+    "wof:lastmodified":1695879559,
     "wof:name":"Novo mesto",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/946/7/1108959467.geojson
+++ b/data/110/895/946/7/1108959467.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Mislinja"
     ],
@@ -88,8 +91,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_076",
-        "eurostat:nuts_2021_id":"076"
+        "eurostat:nuts_2021_id":"076",
+        "svn-sma:id":"076"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417055,
     "wof:geomhash":"3e993d5428b29645c06d0c9df251521a",
@@ -108,7 +113,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354760,
+    "wof:lastmodified":1695879559,
     "wof:name":"Mislinja",
     "wof:parent_id":1108959955,
     "wof:placetype":"localadmin",

--- a/data/110/895/946/9/1108959469.geojson
+++ b/data/110/895/946/9/1108959469.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Kungota"
     ],
@@ -70,8 +73,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_055",
-        "eurostat:nuts_2021_id":"055"
+        "eurostat:nuts_2021_id":"055",
+        "svn-sma:id":"055"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417055,
     "wof:geomhash":"0e8590fe694e2704506b302ab1730b55",
@@ -90,7 +95,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354760,
+    "wof:lastmodified":1695879559,
     "wof:name":"Kungota",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/947/3/1108959473.geojson
+++ b/data/110/895/947/3/1108959473.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Kr\u0161ko"
     ],
@@ -175,8 +178,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_054",
-        "eurostat:nuts_2021_id":"054"
+        "eurostat:nuts_2021_id":"054",
+        "svn-sma:id":"054"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417056,
     "wof:geomhash":"8b7ec2ec1df58fe91f5496428dff9e38",
@@ -195,7 +200,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354760,
+    "wof:lastmodified":1695879559,
     "wof:name":"Kr\u0161ko",
     "wof:parent_id":1108959965,
     "wof:placetype":"localadmin",

--- a/data/110/895/947/5/1108959475.geojson
+++ b/data/110/895/947/5/1108959475.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Lendava"
     ],
@@ -166,8 +169,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_059",
-        "eurostat:nuts_2021_id":"059"
+        "eurostat:nuts_2021_id":"059",
+        "svn-sma:id":"059"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417056,
     "wof:geomhash":"a505655ffbc492111d4c6f04d9b542b6",
@@ -186,7 +191,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354760,
+    "wof:lastmodified":1695879560,
     "wof:name":"Lendava",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/947/7/1108959477.geojson
+++ b/data/110/895/947/7/1108959477.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Lenart"
     ],
@@ -85,8 +88,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_058",
-        "eurostat:nuts_2021_id":"058"
+        "eurostat:nuts_2021_id":"058",
+        "svn-sma:id":"058"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417056,
     "wof:geomhash":"7955d32036c7e10e8906f49dcd3a56ad",
@@ -105,7 +110,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354760,
+    "wof:lastmodified":1695879560,
     "wof:name":"Lenart",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/947/9/1108959479.geojson
+++ b/data/110/895/947/9/1108959479.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Me\u017eica"
     ],
@@ -133,8 +136,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_074",
-        "eurostat:nuts_2021_id":"074"
+        "eurostat:nuts_2021_id":"074",
+        "svn-sma:id":"074"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417057,
     "wof:geomhash":"b724c2e20e20a084563d0db7a617a975",
@@ -153,7 +158,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354760,
+    "wof:lastmodified":1695879560,
     "wof:name":"Me\u017eica",
     "wof:parent_id":1108959955,
     "wof:placetype":"localadmin",

--- a/data/110/895/948/1/1108959481.geojson
+++ b/data/110/895/948/1/1108959481.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Miren - Kostanjevica"
     ],
@@ -73,8 +76,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_075",
-        "eurostat:nuts_2021_id":"075"
+        "eurostat:nuts_2021_id":"075",
+        "svn-sma:id":"075"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417057,
     "wof:geomhash":"c3a56f62356d0c25ebb5eb0e7bfa8eff",
@@ -93,7 +98,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354761,
+    "wof:lastmodified":1695879560,
     "wof:name":"Miren-Kostanjevica",
     "wof:parent_id":1108959947,
     "wof:placetype":"localadmin",

--- a/data/110/895/948/3/1108959483.geojson
+++ b/data/110/895/948/3/1108959483.geojson
@@ -26,7 +26,10 @@
         "City Municipality of Murska Sobota"
     ],
     "label:eng_x_preferred_placetype":[
-        "city municipality"
+        "urban municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
     ],
     "label:slv_x_preferred_longname":[
         "Mestna ob\u010dina Murska Sobota"
@@ -202,8 +205,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_080",
-        "eurostat:nuts_2021_id":"080"
+        "eurostat:nuts_2021_id":"080",
+        "svn-sma:id":"080"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417057,
     "wof:geomhash":"7b403cf57f4c854ce7695dd9ea92e716",
@@ -222,7 +227,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354761,
+    "wof:lastmodified":1695879560,
     "wof:name":"Murska Sobota",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/948/5/1108959485.geojson
+++ b/data/110/895/948/5/1108959485.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Mozirje"
     ],
@@ -133,8 +136,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_079",
-        "eurostat:nuts_2021_id":"079"
+        "eurostat:nuts_2021_id":"079",
+        "svn-sma:id":"079"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417057,
     "wof:geomhash":"aed890bd230dd343c15c17408431b752",
@@ -153,7 +158,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354761,
+    "wof:lastmodified":1695879560,
     "wof:name":"Mozirje",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/948/7/1108959487.geojson
+++ b/data/110/895/948/7/1108959487.geojson
@@ -26,7 +26,10 @@
         "City Municipality of Nova Gorica"
     ],
     "label:eng_x_preferred_placetype":[
-        "city municipality"
+        "urban municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
     ],
     "label:slv_x_preferred_longname":[
         "Mestna ob\u010dina Nova Gorica"
@@ -211,8 +214,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_084",
-        "eurostat:nuts_2021_id":"084"
+        "eurostat:nuts_2021_id":"084",
+        "svn-sma:id":"084"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417058,
     "wof:geomhash":"74130997ce392a5801db6a3f92604a98",
@@ -231,7 +236,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354761,
+    "wof:lastmodified":1695879560,
     "wof:name":"Nova Gorica",
     "wof:parent_id":1108959947,
     "wof:placetype":"localadmin",

--- a/data/110/895/949/1/1108959491.geojson
+++ b/data/110/895/949/1/1108959491.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Maj\u0161perk"
     ],
@@ -91,8 +94,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_069",
-        "eurostat:nuts_2021_id":"069"
+        "eurostat:nuts_2021_id":"069",
+        "svn-sma:id":"069"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417058,
     "wof:geomhash":"9fcd117b8e2bac74a8e8295b80f1a63a",
@@ -111,7 +116,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354761,
+    "wof:lastmodified":1695879560,
     "wof:name":"Maj\u0161perk",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/949/3/1108959493.geojson
+++ b/data/110/895/949/3/1108959493.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Cerklje na Gorenjskem"
     ],
@@ -100,8 +103,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_012",
-        "eurostat:nuts_2021_id":"012"
+        "eurostat:nuts_2021_id":"012",
+        "svn-sma:id":"012"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417058,
     "wof:geomhash":"194fb539940246e32271da0fad98ac3d",
@@ -120,7 +125,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354761,
+    "wof:lastmodified":1695879560,
     "wof:name":"Cerklje na Gorenjskem",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/949/5/1108959495.geojson
+++ b/data/110/895/949/5/1108959495.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Dravograd"
     ],
@@ -148,8 +151,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_025",
-        "eurostat:nuts_2021_id":"025"
+        "eurostat:nuts_2021_id":"025",
+        "svn-sma:id":"025"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417059,
     "wof:geomhash":"faa6d04661e7be0d07580940760a910e",
@@ -168,7 +173,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354761,
+    "wof:lastmodified":1695879560,
     "wof:name":"Dravograd",
     "wof:parent_id":1108959955,
     "wof:placetype":"localadmin",

--- a/data/110/895/949/7/1108959497.geojson
+++ b/data/110/895/949/7/1108959497.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Naklo"
     ],
@@ -97,8 +100,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_082",
-        "eurostat:nuts_2021_id":"082"
+        "eurostat:nuts_2021_id":"082",
+        "svn-sma:id":"082"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417059,
     "wof:geomhash":"13bacd2f6e8a7a7e27d32bb28898dc67",
@@ -117,7 +122,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354761,
+    "wof:lastmodified":1695879560,
     "wof:name":"Naklo",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/949/9/1108959499.geojson
+++ b/data/110/895/949/9/1108959499.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Ljutomer"
     ],
@@ -121,8 +124,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_063",
-        "eurostat:nuts_2021_id":"063"
+        "eurostat:nuts_2021_id":"063",
+        "svn-sma:id":"063"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417059,
     "wof:geomhash":"683049e5cba587a37dc31870956ac95c",
@@ -141,7 +146,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354761,
+    "wof:lastmodified":1695879560,
     "wof:name":"Ljutomer",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/950/1/1108959501.geojson
+++ b/data/110/895/950/1/1108959501.geojson
@@ -26,7 +26,10 @@
         "City Municipality of Ljubljana"
     ],
     "label:eng_x_preferred_placetype":[
-        "city municipality"
+        "urban municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
     ],
     "label:slv_x_preferred_longname":[
         "Mestna ob\u010dina Ljubljana"
@@ -505,8 +508,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_061",
-        "eurostat:nuts_2021_id":"061"
+        "eurostat:nuts_2021_id":"061",
+        "svn-sma:id":"061"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417059,
     "wof:geomhash":"6ad3756bbf754408e5a8cd297cd3d4be",
@@ -525,7 +530,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354762,
+    "wof:lastmodified":1695879561,
     "wof:name":"Ljubljana",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/950/3/1108959503.geojson
+++ b/data/110/895/950/3/1108959503.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Ljubno"
     ],
@@ -70,8 +73,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_062",
-        "eurostat:nuts_2021_id":"062"
+        "eurostat:nuts_2021_id":"062",
+        "svn-sma:id":"062"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417061,
     "wof:geomhash":"13db80e0ddb25707a65434a6d6995e68",
@@ -90,7 +95,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354762,
+    "wof:lastmodified":1695879561,
     "wof:name":"Ljubno",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/950/5/1108959505.geojson
+++ b/data/110/895/950/5/1108959505.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Lu\u010de"
     ],
@@ -91,8 +94,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_067",
-        "eurostat:nuts_2021_id":"067"
+        "eurostat:nuts_2021_id":"067",
+        "svn-sma:id":"067"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417061,
     "wof:geomhash":"2926415b5c82d9e1dfb274e1e400b589",
@@ -111,7 +116,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354762,
+    "wof:lastmodified":1695879561,
     "wof:name":"Lu\u010de",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/950/9/1108959509.geojson
+++ b/data/110/895/950/9/1108959509.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Menge\u0161"
     ],
@@ -103,8 +106,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_072",
-        "eurostat:nuts_2021_id":"072"
+        "eurostat:nuts_2021_id":"072",
+        "svn-sma:id":"072"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417062,
     "wof:geomhash":"020f38ed6472fd0910d876fb5055858a",
@@ -123,7 +128,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354762,
+    "wof:lastmodified":1695879561,
     "wof:name":"Menge\u0161",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/951/1/1108959511.geojson
+++ b/data/110/895/951/1/1108959511.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Kuzma"
     ],
@@ -97,8 +100,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_056",
-        "eurostat:nuts_2021_id":"056"
+        "eurostat:nuts_2021_id":"056",
+        "svn-sma:id":"056"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417062,
     "wof:geomhash":"bd17f5c8d9e28d8e399635257f6b82ee",
@@ -117,7 +122,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354762,
+    "wof:lastmodified":1695879561,
     "wof:name":"Kuzma",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/951/3/1108959513.geojson
+++ b/data/110/895/951/3/1108959513.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Lo\u0161ki Potok"
     ],
@@ -64,8 +67,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_066",
-        "eurostat:nuts_2021_id":"066"
+        "eurostat:nuts_2021_id":"066",
+        "svn-sma:id":"066"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417062,
     "wof:geomhash":"ae6649bb9067b8d275b5f44e2b2d7b1d",
@@ -84,7 +89,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354762,
+    "wof:lastmodified":1695879561,
     "wof:name":"Lo\u0161ki Potok",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/951/5/1108959515.geojson
+++ b/data/110/895/951/5/1108959515.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Morav\u010de"
     ],
@@ -64,8 +67,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_077",
-        "eurostat:nuts_2021_id":"077"
+        "eurostat:nuts_2021_id":"077",
+        "svn-sma:id":"077"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417062,
     "wof:geomhash":"345fd4ec14674f31ab7dc2e811d8922e",
@@ -84,7 +89,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354762,
+    "wof:lastmodified":1695879561,
     "wof:name":"Morav\u010de",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/951/7/1108959517.geojson
+++ b/data/110/895/951/7/1108959517.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Beltinci"
     ],
@@ -136,8 +139,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_002",
-        "eurostat:nuts_2021_id":"002"
+        "eurostat:nuts_2021_id":"002",
+        "svn-sma:id":"002"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417063,
     "wof:geomhash":"545a7f2fc483a4b416b7cbc4b036244d",
@@ -156,7 +161,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354762,
+    "wof:lastmodified":1695879561,
     "wof:name":"Beltinci",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/951/9/1108959519.geojson
+++ b/data/110/895/951/9/1108959519.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Ti\u0161ina"
     ],
@@ -118,8 +121,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_010",
-        "eurostat:nuts_2021_id":"010"
+        "eurostat:nuts_2021_id":"010",
+        "svn-sma:id":"010"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417063,
     "wof:geomhash":"8eb3db69bbd4633241c45def85f5f6d9",
@@ -138,7 +143,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354763,
+    "wof:lastmodified":1695879561,
     "wof:name":"Ti\u0161ina",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/952/1/1108959521.geojson
+++ b/data/110/895/952/1/1108959521.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Kobilje"
     ],
@@ -133,8 +136,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_047",
-        "eurostat:nuts_2021_id":"047"
+        "eurostat:nuts_2021_id":"047",
+        "svn-sma:id":"047"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417063,
     "wof:geomhash":"0322000ad12a5c831fa0eb782d83f1c0",
@@ -153,7 +158,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354763,
+    "wof:lastmodified":1695879561,
     "wof:name":"Kobilje",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/952/3/1108959523.geojson
+++ b/data/110/895/952/3/1108959523.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Kobarid"
     ],
@@ -163,8 +166,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_046",
-        "eurostat:nuts_2021_id":"046"
+        "eurostat:nuts_2021_id":"046",
+        "svn-sma:id":"046"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417063,
     "wof:geomhash":"5a0008dabaae9c0c0cba58b73a25a592",
@@ -183,7 +188,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354763,
+    "wof:lastmodified":1695879561,
     "wof:name":"Kobarid",
     "wof:parent_id":1108959947,
     "wof:placetype":"localadmin",

--- a/data/110/895/952/7/1108959527.geojson
+++ b/data/110/895/952/7/1108959527.geojson
@@ -26,7 +26,10 @@
         "City Municipality of Koper"
     ],
     "label:eng_x_preferred_placetype":[
-        "city municipality"
+        "urban municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
     ],
     "label:slv_x_preferred_longname":[
         "Mestna ob\u010dina Koper"
@@ -241,8 +244,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_050",
-        "eurostat:nuts_2021_id":"050"
+        "eurostat:nuts_2021_id":"050",
+        "svn-sma:id":"050"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417064,
     "wof:geomhash":"f1edbf060ade70a72f3b71dc27d2d45e",
@@ -261,7 +266,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354763,
+    "wof:lastmodified":1695879561,
     "wof:name":"Koper",
     "wof:parent_id":1108959951,
     "wof:placetype":"localadmin",

--- a/data/110/895/952/9/1108959529.geojson
+++ b/data/110/895/952/9/1108959529.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Duplek"
     ],
@@ -67,8 +70,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_026",
-        "eurostat:nuts_2021_id":"026"
+        "eurostat:nuts_2021_id":"026",
+        "svn-sma:id":"026"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417064,
     "wof:geomhash":"30d694e4cc04eabe28cd24e413520e2f",
@@ -87,7 +92,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354763,
+    "wof:lastmodified":1695879562,
     "wof:name":"Duplek",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/953/1/1108959531.geojson
+++ b/data/110/895/953/1/1108959531.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Gornji Petrovci"
     ],
@@ -121,8 +124,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_031",
-        "eurostat:nuts_2021_id":"031"
+        "eurostat:nuts_2021_id":"031",
+        "svn-sma:id":"031"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417064,
     "wof:geomhash":"5777c13e4233bc4ad66179f1f4ab02b6",
@@ -141,7 +146,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354763,
+    "wof:lastmodified":1695879562,
     "wof:name":"Gornji Petrovci",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/953/3/1108959533.geojson
+++ b/data/110/895/953/3/1108959533.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Grosuplje"
     ],
@@ -136,8 +139,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_032",
-        "eurostat:nuts_2021_id":"032"
+        "eurostat:nuts_2021_id":"032",
+        "svn-sma:id":"032"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417064,
     "wof:geomhash":"f1c4b4187702a3ef8cef2065268a06a4",
@@ -156,7 +161,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354763,
+    "wof:lastmodified":1695879562,
     "wof:name":"Grosuplje",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/953/5/1108959535.geojson
+++ b/data/110/895/953/5/1108959535.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Idrija"
     ],
@@ -181,8 +184,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_036",
-        "eurostat:nuts_2021_id":"036"
+        "eurostat:nuts_2021_id":"036",
+        "svn-sma:id":"036"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417065,
     "wof:geomhash":"08b7d400bd6db0934bef072e84deeae9",
@@ -201,7 +206,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354763,
+    "wof:lastmodified":1695879562,
     "wof:name":"Idrija",
     "wof:parent_id":1108959947,
     "wof:placetype":"localadmin",

--- a/data/110/895/953/7/1108959537.geojson
+++ b/data/110/895/953/7/1108959537.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Kanal ob So\u010di"
     ],
@@ -151,8 +154,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_044",
-        "eurostat:nuts_2021_id":"044"
+        "eurostat:nuts_2021_id":"044",
+        "svn-sma:id":"044"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417065,
     "wof:geomhash":"004d6e5c2525944d19b99508b845082d",
@@ -171,7 +176,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354763,
+    "wof:lastmodified":1695879562,
     "wof:name":"Kanal",
     "wof:parent_id":1108959947,
     "wof:placetype":"localadmin",

--- a/data/110/895/953/9/1108959539.geojson
+++ b/data/110/895/953/9/1108959539.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Komen"
     ],
@@ -151,8 +154,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_049",
-        "eurostat:nuts_2021_id":"049"
+        "eurostat:nuts_2021_id":"049",
+        "svn-sma:id":"049"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417066,
     "wof:geomhash":"a475a45af1f78cf660029c0f9798a5ad",
@@ -171,7 +176,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354764,
+    "wof:lastmodified":1695879562,
     "wof:name":"Komen",
     "wof:parent_id":1108959951,
     "wof:placetype":"localadmin",

--- a/data/110/895/954/1/1108959541.geojson
+++ b/data/110/895/954/1/1108959541.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Bovec"
     ],
@@ -160,8 +163,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_006",
-        "eurostat:nuts_2021_id":"006"
+        "eurostat:nuts_2021_id":"006",
+        "svn-sma:id":"006"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417066,
     "wof:geomhash":"06a2bd4affa9c1278f96ee175750a717",
@@ -180,7 +185,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354764,
+    "wof:lastmodified":1695879562,
     "wof:name":"Bovec",
     "wof:parent_id":1108959947,
     "wof:placetype":"localadmin",

--- a/data/110/895/954/5/1108959545.geojson
+++ b/data/110/895/954/5/1108959545.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Ajdov\u0161\u010dina"
     ],
@@ -121,8 +124,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_001",
-        "eurostat:nuts_2021_id":"001"
+        "eurostat:nuts_2021_id":"001",
+        "svn-sma:id":"001"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417066,
     "wof:geomhash":"b775ec79adec109a70b73bc34067bb5f",
@@ -141,7 +146,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354764,
+    "wof:lastmodified":1695879562,
     "wof:name":"Ajdov\u0161\u010dina",
     "wof:parent_id":1108959947,
     "wof:placetype":"localadmin",

--- a/data/110/895/954/7/1108959547.geojson
+++ b/data/110/895/954/7/1108959547.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Gornji Grad"
     ],
@@ -97,8 +100,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_030",
-        "eurostat:nuts_2021_id":"030"
+        "eurostat:nuts_2021_id":"030",
+        "svn-sma:id":"030"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417067,
     "wof:geomhash":"5e97636bb827e283d6b2f885de03ac06",
@@ -117,7 +122,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354764,
+    "wof:lastmodified":1695879562,
     "wof:name":"Gornji Grad",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/954/9/1108959549.geojson
+++ b/data/110/895/954/9/1108959549.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Hrpelje - Kozina"
     ],
@@ -73,8 +76,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_035",
-        "eurostat:nuts_2021_id":"035"
+        "eurostat:nuts_2021_id":"035",
+        "svn-sma:id":"035"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417067,
     "wof:geomhash":"7319c23f56f6fcd09af156a012cc518b",
@@ -93,7 +98,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354764,
+    "wof:lastmodified":1695879562,
     "wof:name":"Hrpelje-Kozina",
     "wof:parent_id":1108959951,
     "wof:placetype":"localadmin",

--- a/data/110/895/955/1/1108959551.geojson
+++ b/data/110/895/955/1/1108959551.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Izola"
     ],
@@ -181,8 +184,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_040",
-        "eurostat:nuts_2021_id":"040"
+        "eurostat:nuts_2021_id":"040",
+        "svn-sma:id":"040"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417067,
     "wof:geomhash":"d2bd0492d23ac8e936f922f70f83124b",
@@ -201,7 +206,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354764,
+    "wof:lastmodified":1695879563,
     "wof:name":"Izola",
     "wof:parent_id":1108959951,
     "wof:placetype":"localadmin",

--- a/data/110/895/955/3/1108959553.geojson
+++ b/data/110/895/955/3/1108959553.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Pesnica"
     ],
@@ -94,8 +97,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_089",
-        "eurostat:nuts_2021_id":"089"
+        "eurostat:nuts_2021_id":"089",
+        "svn-sma:id":"089"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417067,
     "wof:geomhash":"48a189bfe8449602eb6436e8252e8475",
@@ -114,7 +119,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354764,
+    "wof:lastmodified":1695879563,
     "wof:name":"Pesnica",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/955/5/1108959555.geojson
+++ b/data/110/895/955/5/1108959555.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Podvelka"
     ],
@@ -130,8 +133,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_093",
-        "eurostat:nuts_2021_id":"093"
+        "eurostat:nuts_2021_id":"093",
+        "svn-sma:id":"093"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417068,
     "wof:geomhash":"2f0ef5fd618f76118517a72e62d0784f",
@@ -150,7 +155,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354765,
+    "wof:lastmodified":1695879563,
     "wof:name":"Podvelka",
     "wof:parent_id":1108959955,
     "wof:placetype":"localadmin",

--- a/data/110/895/955/7/1108959557.geojson
+++ b/data/110/895/955/7/1108959557.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Radlje ob Dravi"
     ],
@@ -97,8 +100,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_101",
-        "eurostat:nuts_2021_id":"101"
+        "eurostat:nuts_2021_id":"101",
+        "svn-sma:id":"101"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417068,
     "wof:geomhash":"5a1e94534ea1d783673404f70ade70d3",
@@ -117,7 +122,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354765,
+    "wof:lastmodified":1695879563,
     "wof:name":"Radlje ob Dravi",
     "wof:parent_id":1108959955,
     "wof:placetype":"localadmin",

--- a/data/110/895/955/9/1108959559.geojson
+++ b/data/110/895/955/9/1108959559.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Postojna"
     ],
@@ -175,8 +178,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_094",
-        "eurostat:nuts_2021_id":"094"
+        "eurostat:nuts_2021_id":"094",
+        "svn-sma:id":"094"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417068,
     "wof:geomhash":"fea8618d7a87a8f6904910671236e182",
@@ -195,7 +200,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354766,
+    "wof:lastmodified":1695879563,
     "wof:name":"Postojna",
     "wof:parent_id":1108959953,
     "wof:placetype":"localadmin",

--- a/data/110/895/956/3/1108959563.geojson
+++ b/data/110/895/956/3/1108959563.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Osilnica"
     ],
@@ -88,8 +91,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_088",
-        "eurostat:nuts_2021_id":"088"
+        "eurostat:nuts_2021_id":"088",
+        "svn-sma:id":"088"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417068,
     "wof:geomhash":"bb5aef47d37e9e7d8431338357d7b4fd",
@@ -108,7 +113,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354766,
+    "wof:lastmodified":1695879563,
     "wof:name":"Osilnica",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/956/5/1108959565.geojson
+++ b/data/110/895/956/5/1108959565.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina \u0160entilj"
     ],
@@ -64,8 +67,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_118",
-        "eurostat:nuts_2021_id":"118"
+        "eurostat:nuts_2021_id":"118",
+        "svn-sma:id":"118"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417069,
     "wof:geomhash":"59a7ee5c54907c9e311696af5585d112",
@@ -84,7 +89,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354766,
+    "wof:lastmodified":1695879563,
     "wof:name":"\u0160entilj",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/956/7/1108959567.geojson
+++ b/data/110/895/956/7/1108959567.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina \u0160alovci"
     ],
@@ -121,8 +124,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_033",
-        "eurostat:nuts_2021_id":"033"
+        "eurostat:nuts_2021_id":"033",
+        "svn-sma:id":"033"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417069,
     "wof:geomhash":"a70f6b93a025ed203cdfcba3ea3e232c",
@@ -141,7 +146,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354766,
+    "wof:lastmodified":1695879563,
     "wof:name":"\u0160alovci",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/956/9/1108959569.geojson
+++ b/data/110/895/956/9/1108959569.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Radenci"
     ],
@@ -127,8 +130,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_100",
-        "eurostat:nuts_2021_id":"100"
+        "eurostat:nuts_2021_id":"100",
+        "svn-sma:id":"100"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417069,
     "wof:geomhash":"1fa9260aeb15f04d8ea3b610a3adfbd7",
@@ -147,7 +152,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354766,
+    "wof:lastmodified":1695879563,
     "wof:name":"Radenci",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/957/1/1108959571.geojson
+++ b/data/110/895/957/1/1108959571.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Hrastnik"
     ],
@@ -142,8 +145,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_034",
-        "eurostat:nuts_2021_id":"034"
+        "eurostat:nuts_2021_id":"034",
+        "svn-sma:id":"034"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417069,
     "wof:geomhash":"3867e04d53e829a2ffba2606df079cbd",
@@ -162,7 +167,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354767,
+    "wof:lastmodified":1695879563,
     "wof:name":"Hrastnik",
     "wof:parent_id":1108959963,
     "wof:placetype":"localadmin",

--- a/data/110/895/957/3/1108959573.geojson
+++ b/data/110/895/957/3/1108959573.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina \u010crna na Koro\u0161kem"
     ],
@@ -97,8 +100,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_016",
-        "eurostat:nuts_2021_id":"016"
+        "eurostat:nuts_2021_id":"016",
+        "svn-sma:id":"016"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417075,
     "wof:geomhash":"2beeefe7d38d9c8fd6eb0764fc773513",
@@ -117,7 +122,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354767,
+    "wof:lastmodified":1695879563,
     "wof:name":"\u010crna na Koro\u0161kem",
     "wof:parent_id":1108959955,
     "wof:placetype":"localadmin",

--- a/data/110/895/957/5/1108959575.geojson
+++ b/data/110/895/957/5/1108959575.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Dobrepolje"
     ],
@@ -67,8 +70,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_020",
-        "eurostat:nuts_2021_id":"020"
+        "eurostat:nuts_2021_id":"020",
+        "svn-sma:id":"020"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417075,
     "wof:geomhash":"a169879c36dbd05a7c971801a06a486f",
@@ -87,7 +92,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354767,
+    "wof:lastmodified":1695879563,
     "wof:name":"Dobrepolje",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/957/7/1108959577.geojson
+++ b/data/110/895/957/7/1108959577.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Cerkno"
     ],
@@ -127,8 +130,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_014",
-        "eurostat:nuts_2021_id":"014"
+        "eurostat:nuts_2021_id":"014",
+        "svn-sma:id":"014"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417076,
     "wof:geomhash":"49c1d24f6d471deb6ba640d817986ac5",
@@ -147,7 +152,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354767,
+    "wof:lastmodified":1695879564,
     "wof:name":"Cerkno",
     "wof:parent_id":1108959947,
     "wof:placetype":"localadmin",

--- a/data/110/895/958/1/1108959581.geojson
+++ b/data/110/895/958/1/1108959581.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Kozje"
     ],
@@ -124,8 +127,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_051",
-        "eurostat:nuts_2021_id":"051"
+        "eurostat:nuts_2021_id":"051",
+        "svn-sma:id":"051"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417076,
     "wof:geomhash":"39f844fc353d03154f7136b35d27334c",
@@ -144,7 +149,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354767,
+    "wof:lastmodified":1695879564,
     "wof:name":"Kozje",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/958/3/1108959583.geojson
+++ b/data/110/895/958/3/1108959583.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Ivan\u010dna Gorica"
     ],
@@ -124,8 +127,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_039",
-        "eurostat:nuts_2021_id":"039"
+        "eurostat:nuts_2021_id":"039",
+        "svn-sma:id":"039"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417076,
     "wof:geomhash":"aa4e38e5dfd411a3f3419819074da8c3",
@@ -144,7 +149,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354767,
+    "wof:lastmodified":1695879564,
     "wof:name":"Ivan\u010dna Gorica",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/958/5/1108959585.geojson
+++ b/data/110/895/958/5/1108959585.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Bre\u017eice"
     ],
@@ -160,8 +163,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_009",
-        "eurostat:nuts_2021_id":"009"
+        "eurostat:nuts_2021_id":"009",
+        "svn-sma:id":"009"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417077,
     "wof:geomhash":"fa30b6352a0628463b44bfeb3134e477",
@@ -180,7 +185,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354767,
+    "wof:lastmodified":1695879564,
     "wof:name":"Bre\u017eice",
     "wof:parent_id":1108959965,
     "wof:placetype":"localadmin",

--- a/data/110/895/958/7/1108959587.geojson
+++ b/data/110/895/958/7/1108959587.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Pivka"
     ],
@@ -106,8 +109,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_091",
-        "eurostat:nuts_2021_id":"091"
+        "eurostat:nuts_2021_id":"091",
+        "svn-sma:id":"091"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417078,
     "wof:geomhash":"b2a0baf873fbaf953bfc67032697d574",
@@ -126,7 +131,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354768,
+    "wof:lastmodified":1695879564,
     "wof:name":"Pivka",
     "wof:parent_id":1108959953,
     "wof:placetype":"localadmin",

--- a/data/110/895/958/9/1108959589.geojson
+++ b/data/110/895/958/9/1108959589.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Ra\u010de - Fram"
     ],
@@ -64,8 +67,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_098",
-        "eurostat:nuts_2021_id":"098"
+        "eurostat:nuts_2021_id":"098",
+        "svn-sma:id":"098"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417079,
     "wof:geomhash":"c2e41a93946875410de30f30468793af",
@@ -84,7 +89,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354768,
+    "wof:lastmodified":1695879564,
     "wof:name":"Ra\u010de-Fram",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/959/1/1108959591.geojson
+++ b/data/110/895/959/1/1108959591.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Sveti Jurij ob \u0160\u010davnici"
     ],
@@ -115,8 +118,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_116",
-        "eurostat:nuts_2021_id":"116"
+        "eurostat:nuts_2021_id":"116",
+        "svn-sma:id":"116"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417079,
     "wof:geomhash":"03ff4226dadda735a4f2dedebe5d4c1f",
@@ -135,7 +140,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354768,
+    "wof:lastmodified":1695879564,
     "wof:name":"Sveti Jurij ob \u0160\u010davnici",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/959/3/1108959593.geojson
+++ b/data/110/895/959/3/1108959593.geojson
@@ -26,7 +26,10 @@
         "City Municipality of Velenje"
     ],
     "label:eng_x_preferred_placetype":[
-        "city municipality"
+        "urban municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
     ],
     "label:slv_x_preferred_longname":[
         "Mestna ob\u010dina Velenje"
@@ -202,8 +205,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_133",
-        "eurostat:nuts_2021_id":"133"
+        "eurostat:nuts_2021_id":"133",
+        "svn-sma:id":"133"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417079,
     "wof:geomhash":"12061625aecb6c452f45ec6bbe02697a",
@@ -222,7 +227,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354768,
+    "wof:lastmodified":1695879564,
     "wof:name":"Velenje",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/959/5/1108959595.geojson
+++ b/data/110/895/959/5/1108959595.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Odranci"
     ],
@@ -136,8 +139,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_086",
-        "eurostat:nuts_2021_id":"086"
+        "eurostat:nuts_2021_id":"086",
+        "svn-sma:id":"086"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417080,
     "wof:geomhash":"d62fd80d1c9cbaf1b3d7d02b878af174",
@@ -156,7 +161,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354768,
+    "wof:lastmodified":1695879565,
     "wof:name":"Odranci",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/959/9/1108959599.geojson
+++ b/data/110/895/959/9/1108959599.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Ribnica"
     ],
@@ -118,8 +121,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_104",
-        "eurostat:nuts_2021_id":"104"
+        "eurostat:nuts_2021_id":"104",
+        "svn-sma:id":"104"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417080,
     "wof:geomhash":"74c7df60f34a31279a2a3f6e066934e2",
@@ -138,7 +143,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354768,
+    "wof:lastmodified":1695879565,
     "wof:name":"Ribnica",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/960/1/1108959601.geojson
+++ b/data/110/895/960/1/1108959601.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Semi\u010d"
     ],
@@ -94,8 +97,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_109",
-        "eurostat:nuts_2021_id":"109"
+        "eurostat:nuts_2021_id":"109",
+        "svn-sma:id":"109"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417080,
     "wof:geomhash":"369656beca6f253844eaf45cf96749d4",
@@ -114,7 +119,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354768,
+    "wof:lastmodified":1695879565,
     "wof:name":"Semi\u010d",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/960/3/1108959603.geojson
+++ b/data/110/895/960/3/1108959603.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Turni\u0161\u010de"
     ],
@@ -100,8 +103,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_132",
-        "eurostat:nuts_2021_id":"132"
+        "eurostat:nuts_2021_id":"132",
+        "svn-sma:id":"132"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417080,
     "wof:geomhash":"4f84eb4570b023d320ec55594e225443",
@@ -120,7 +125,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354769,
+    "wof:lastmodified":1695879565,
     "wof:name":"Turni\u0161\u010de",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/960/5/1108959605.geojson
+++ b/data/110/895/960/5/1108959605.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina \u0160kocjan"
     ],
@@ -91,8 +94,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_121",
-        "eurostat:nuts_2021_id":"121"
+        "eurostat:nuts_2021_id":"121",
+        "svn-sma:id":"121"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417081,
     "wof:geomhash":"66cc7c3928bea90029df272dd261e5f4",
@@ -111,7 +116,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354769,
+    "wof:lastmodified":1695879565,
     "wof:name":"\u0160kocjan",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/960/7/1108959607.geojson
+++ b/data/110/895/960/7/1108959607.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina \u0160marje pri Jel\u0161ah"
     ],
@@ -121,8 +124,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_124",
-        "eurostat:nuts_2021_id":"124"
+        "eurostat:nuts_2021_id":"124",
+        "svn-sma:id":"124"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417081,
     "wof:geomhash":"0b50e85b8152d11dd5e419fa9723561c",
@@ -141,7 +146,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354769,
+    "wof:lastmodified":1695879565,
     "wof:name":"\u0160marje pri Jel\u0161ah",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/960/9/1108959609.geojson
+++ b/data/110/895/960/9/1108959609.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Rogatec"
     ],
@@ -97,8 +100,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_107",
-        "eurostat:nuts_2021_id":"107"
+        "eurostat:nuts_2021_id":"107",
+        "svn-sma:id":"107"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417081,
     "wof:geomhash":"a0a8e67f8ff5b4ceefca3723de792e3f",
@@ -117,7 +122,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354769,
+    "wof:lastmodified":1695879565,
     "wof:name":"Rogatec",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/961/1/1108959611.geojson
+++ b/data/110/895/961/1/1108959611.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Ru\u0161e"
     ],
@@ -130,8 +133,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_108",
-        "eurostat:nuts_2021_id":"108"
+        "eurostat:nuts_2021_id":"108",
+        "svn-sma:id":"108"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417081,
     "wof:geomhash":"f513ae9b1d469afe8ecf04a1652ac80b",
@@ -150,7 +155,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354769,
+    "wof:lastmodified":1695879565,
     "wof:name":"Ru\u0161e",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/961/3/1108959613.geojson
+++ b/data/110/895/961/3/1108959613.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Piran"
     ],
@@ -214,8 +217,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_090",
-        "eurostat:nuts_2021_id":"090"
+        "eurostat:nuts_2021_id":"090",
+        "svn-sma:id":"090"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417082,
     "wof:geomhash":"acdad4ccf46135ed82c26e35dc3a6d5f",
@@ -234,7 +239,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354769,
+    "wof:lastmodified":1695879565,
     "wof:name":"Piran",
     "wof:parent_id":1108959951,
     "wof:placetype":"localadmin",

--- a/data/110/895/961/7/1108959617.geojson
+++ b/data/110/895/961/7/1108959617.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Tolmin"
     ],
@@ -106,8 +109,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_128",
-        "eurostat:nuts_2021_id":"128"
+        "eurostat:nuts_2021_id":"128",
+        "svn-sma:id":"128"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417082,
     "wof:geomhash":"fa1d6d2c76852dd9352fff93eaf78846",
@@ -126,7 +131,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354769,
+    "wof:lastmodified":1695879565,
     "wof:name":"Tolmin",
     "wof:parent_id":1108959947,
     "wof:placetype":"localadmin",

--- a/data/110/895/961/9/1108959619.geojson
+++ b/data/110/895/961/9/1108959619.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Zavr\u010d"
     ],
@@ -82,8 +85,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_143",
-        "eurostat:nuts_2021_id":"143"
+        "eurostat:nuts_2021_id":"143",
+        "svn-sma:id":"143"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417082,
     "wof:geomhash":"5d99999cfdf0a89c14b7fa66c1bc75f8",
@@ -102,7 +107,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354769,
+    "wof:lastmodified":1695879566,
     "wof:name":"Zavr\u010d",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/962/1/1108959621.geojson
+++ b/data/110/895/962/1/1108959621.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Dobrna"
     ],
@@ -103,8 +106,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_155",
-        "eurostat:nuts_2021_id":"155"
+        "eurostat:nuts_2021_id":"155",
+        "svn-sma:id":"155"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417083,
     "wof:geomhash":"901c4536dd56fc4d146a30c4a5bf7346",
@@ -123,7 +128,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354769,
+    "wof:lastmodified":1695879566,
     "wof:name":"Dobrna",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/962/3/1108959623.geojson
+++ b/data/110/895/962/3/1108959623.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Vipava"
     ],
@@ -85,8 +88,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_136",
-        "eurostat:nuts_2021_id":"136"
+        "eurostat:nuts_2021_id":"136",
+        "svn-sma:id":"136"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417083,
     "wof:geomhash":"695b7258cfa0183e8030e02d8a61fd9f",
@@ -105,7 +110,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354770,
+    "wof:lastmodified":1695879566,
     "wof:name":"Vipava",
     "wof:parent_id":1108959947,
     "wof:placetype":"localadmin",

--- a/data/110/895/962/5/1108959625.geojson
+++ b/data/110/895/962/5/1108959625.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Jezersko"
     ],
@@ -100,8 +103,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_163",
-        "eurostat:nuts_2021_id":"163"
+        "eurostat:nuts_2021_id":"163",
+        "svn-sma:id":"163"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417083,
     "wof:geomhash":"2c35fff6f7f7acbb46bf8aca4f7f9c23",
@@ -120,7 +125,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354770,
+    "wof:lastmodified":1695879566,
     "wof:name":"Jezersko",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/962/7/1108959627.geojson
+++ b/data/110/895/962/7/1108959627.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Sveti Andra\u017e v Slovenskih goricah"
     ],
@@ -64,8 +67,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_182",
-        "eurostat:nuts_2021_id":"182"
+        "eurostat:nuts_2021_id":"182",
+        "svn-sma:id":"182"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417083,
     "wof:geomhash":"2d7aa96bf2298d336c75b51b99ec6887",
@@ -84,7 +89,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354770,
+    "wof:lastmodified":1695879566,
     "wof:name":"Sveti Andra\u017e v Slov. goricah",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/962/9/1108959629.geojson
+++ b/data/110/895/962/9/1108959629.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina \u0160empeter - Vrtojba"
     ],
@@ -64,8 +67,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_183",
-        "eurostat:nuts_2021_id":"183"
+        "eurostat:nuts_2021_id":"183",
+        "svn-sma:id":"183"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417084,
     "wof:geomhash":"2be0774b7c6fe6c37daa826e1d2954dc",
@@ -84,7 +89,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354770,
+    "wof:lastmodified":1695879566,
     "wof:name":"\u0160empeter-Vrtojba",
     "wof:parent_id":1108959947,
     "wof:placetype":"localadmin",

--- a/data/110/895/963/1/1108959631.geojson
+++ b/data/110/895/963/1/1108959631.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina \u0160tore"
     ],
@@ -124,8 +127,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_127",
-        "eurostat:nuts_2021_id":"127"
+        "eurostat:nuts_2021_id":"127",
+        "svn-sma:id":"127"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417085,
     "wof:geomhash":"7beedc8ac48e071be00a3ffd34b81c4b",
@@ -144,7 +149,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354770,
+    "wof:lastmodified":1695879566,
     "wof:name":"\u0160tore",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/963/5/1108959635.geojson
+++ b/data/110/895/963/5/1108959635.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Polzela"
     ],
@@ -136,8 +139,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_173",
-        "eurostat:nuts_2021_id":"173"
+        "eurostat:nuts_2021_id":"173",
+        "svn-sma:id":"173"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417085,
     "wof:geomhash":"5df1df2e1b3d51af237e1acfb665262d",
@@ -156,7 +161,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354770,
+    "wof:lastmodified":1695879566,
     "wof:name":"Polzela",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/963/7/1108959637.geojson
+++ b/data/110/895/963/7/1108959637.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Hodo\u0161"
     ],
@@ -124,8 +127,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_161",
-        "eurostat:nuts_2021_id":"161"
+        "eurostat:nuts_2021_id":"161",
+        "svn-sma:id":"161"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417085,
     "wof:geomhash":"39775632bf529f95c1484f0f578be137",
@@ -144,7 +149,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354770,
+    "wof:lastmodified":1695879566,
     "wof:name":"Hodo\u0161",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/963/9/1108959639.geojson
+++ b/data/110/895/963/9/1108959639.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Sol\u010dava"
     ],
@@ -118,8 +121,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_180",
-        "eurostat:nuts_2021_id":"180"
+        "eurostat:nuts_2021_id":"180",
+        "svn-sma:id":"180"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417086,
     "wof:geomhash":"d648990fe0194e892e126c32cedc02a1",
@@ -138,7 +143,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354770,
+    "wof:lastmodified":1695879566,
     "wof:name":"Sol\u010dava",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/964/1/1108959641.geojson
+++ b/data/110/895/964/1/1108959641.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Slovenska Bistrica"
     ],
@@ -157,8 +160,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_113",
-        "eurostat:nuts_2021_id":"113"
+        "eurostat:nuts_2021_id":"113",
+        "svn-sma:id":"113"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417086,
     "wof:geomhash":"f9190664eab3970d63ccf20b6b376bb5",
@@ -177,7 +182,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354770,
+    "wof:lastmodified":1695879566,
     "wof:name":"Slovenska Bistrica",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/964/3/1108959643.geojson
+++ b/data/110/895/964/3/1108959643.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Ravne na Koro\u0161kem"
     ],
@@ -148,8 +151,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_103",
-        "eurostat:nuts_2021_id":"103"
+        "eurostat:nuts_2021_id":"103",
+        "svn-sma:id":"103"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417086,
     "wof:geomhash":"df3be03214192090f98d0d50c58e6464",
@@ -168,7 +173,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354770,
+    "wof:lastmodified":1695879566,
     "wof:name":"Ravne na Koro\u0161kem",
     "wof:parent_id":1108959955,
     "wof:placetype":"localadmin",

--- a/data/110/895/964/5/1108959645.geojson
+++ b/data/110/895/964/5/1108959645.geojson
@@ -26,7 +26,10 @@
         "City Municipality of Slovenj Gradec"
     ],
     "label:eng_x_preferred_placetype":[
-        "city municipality"
+        "urban municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
     ],
     "label:slv_x_preferred_longname":[
         "Mestna ob\u010dina Slovenj Gradec"
@@ -194,8 +197,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_112",
-        "eurostat:nuts_2021_id":"112"
+        "eurostat:nuts_2021_id":"112",
+        "svn-sma:id":"112"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417086,
     "wof:geomhash":"a9b5a6e36b02da5444630b28d11702ac",
@@ -214,7 +219,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354770,
+    "wof:lastmodified":1695879566,
     "wof:name":"Slovenj Gradec",
     "wof:parent_id":1108959955,
     "wof:placetype":"localadmin",

--- a/data/110/895/964/7/1108959647.geojson
+++ b/data/110/895/964/7/1108959647.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina \u0160en\u010dur"
     ],
@@ -91,8 +94,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_117",
-        "eurostat:nuts_2021_id":"117"
+        "eurostat:nuts_2021_id":"117",
+        "svn-sma:id":"117"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417087,
     "wof:geomhash":"194f3d7b8ecfc6a0d11a7f3b66b6290f",
@@ -111,7 +116,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354771,
+    "wof:lastmodified":1695879567,
     "wof:name":"\u0160en\u010dur",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/964/9/1108959649.geojson
+++ b/data/110/895/964/9/1108959649.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Pod\u010detrtek"
     ],
@@ -124,8 +127,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_092",
-        "eurostat:nuts_2021_id":"092"
+        "eurostat:nuts_2021_id":"092",
+        "svn-sma:id":"092"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417087,
     "wof:geomhash":"0ae907fda8d0bfdeb2035f588d766986",
@@ -144,7 +149,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354771,
+    "wof:lastmodified":1695879567,
     "wof:name":"Pod\u010detrtek",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/965/3/1108959653.geojson
+++ b/data/110/895/965/3/1108959653.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Vojnik"
     ],
@@ -91,8 +94,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_139",
-        "eurostat:nuts_2021_id":"139"
+        "eurostat:nuts_2021_id":"139",
+        "svn-sma:id":"139"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417087,
     "wof:geomhash":"2c6aef423434588f620838e0dc66881d",
@@ -111,7 +116,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354771,
+    "wof:lastmodified":1695879567,
     "wof:name":"Vojnik",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/965/5/1108959655.geojson
+++ b/data/110/895/965/5/1108959655.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Roga\u0161ovci"
     ],
@@ -124,8 +127,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_105",
-        "eurostat:nuts_2021_id":"105"
+        "eurostat:nuts_2021_id":"105",
+        "svn-sma:id":"105"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417087,
     "wof:geomhash":"cd3555082a6cf97d18f31e27dc5c710f",
@@ -144,7 +149,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354771,
+    "wof:lastmodified":1695879567,
     "wof:name":"Roga\u0161ovci",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/965/7/1108959657.geojson
+++ b/data/110/895/965/7/1108959657.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Preddvor"
     ],
@@ -103,8 +106,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_095",
-        "eurostat:nuts_2021_id":"095"
+        "eurostat:nuts_2021_id":"095",
+        "svn-sma:id":"095"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417088,
     "wof:geomhash":"f027d26957a8826896b43848c08e7b08",
@@ -123,7 +128,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354771,
+    "wof:lastmodified":1695879567,
     "wof:name":"Preddvor",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/965/9/1108959659.geojson
+++ b/data/110/895/965/9/1108959659.geojson
@@ -26,7 +26,10 @@
         "City Municipality of Ptuj"
     ],
     "label:eng_x_preferred_placetype":[
-        "city municipality"
+        "urban municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
     ],
     "label:slv_x_preferred_longname":[
         "Mestna ob\u010dina Ptuj"
@@ -217,8 +220,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_096",
-        "eurostat:nuts_2021_id":"096"
+        "eurostat:nuts_2021_id":"096",
+        "svn-sma:id":"096"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417088,
     "wof:geomhash":"30b5ca5cb711244558cf3e021b1d178a",
@@ -237,7 +242,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354771,
+    "wof:lastmodified":1695879567,
     "wof:name":"Ptuj",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/966/1/1108959661.geojson
+++ b/data/110/895/966/1/1108959661.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Selnica ob Dravi"
     ],
@@ -130,8 +133,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_178",
-        "eurostat:nuts_2021_id":"178"
+        "eurostat:nuts_2021_id":"178",
+        "svn-sma:id":"178"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417088,
     "wof:geomhash":"1059282c899a4f9fecf2f9aaa9e31121",
@@ -150,7 +155,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354771,
+    "wof:lastmodified":1695879567,
     "wof:name":"Selnica ob Dravi",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/966/3/1108959663.geojson
+++ b/data/110/895/966/3/1108959663.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Grad"
     ],
@@ -151,8 +154,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_158",
-        "eurostat:nuts_2021_id":"158"
+        "eurostat:nuts_2021_id":"158",
+        "svn-sma:id":"158"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417089,
     "wof:geomhash":"f8cb614d491587bf652bfc4c340ef322",
@@ -171,7 +176,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354771,
+    "wof:lastmodified":1695879567,
     "wof:name":"Grad",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/966/5/1108959665.geojson
+++ b/data/110/895/966/5/1108959665.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Miklav\u017e na Dravskem polju"
     ],
@@ -64,8 +67,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_169",
-        "eurostat:nuts_2021_id":"169"
+        "eurostat:nuts_2021_id":"169",
+        "svn-sma:id":"169"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417089,
     "wof:geomhash":"270e559b468b0ea7dfb5499b7c1b0f89",
@@ -84,7 +89,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354772,
+    "wof:lastmodified":1695879567,
     "wof:name":"Miklav\u017e na Dravskem polju",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/966/7/1108959667.geojson
+++ b/data/110/895/966/7/1108959667.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Apa\u010de"
     ],
@@ -127,8 +130,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_195",
-        "eurostat:nuts_2021_id":"195"
+        "eurostat:nuts_2021_id":"195",
+        "svn-sma:id":"195"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417090,
     "wof:geomhash":"6f49f6b2e60dfe95c928a23602e3604f",
@@ -147,7 +152,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354772,
+    "wof:lastmodified":1695879567,
     "wof:name":"Apa\u010de",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/967/1/1108959671.geojson
+++ b/data/110/895/967/1/1108959671.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Zre\u010de"
     ],
@@ -91,8 +94,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_144",
-        "eurostat:nuts_2021_id":"144"
+        "eurostat:nuts_2021_id":"144",
+        "svn-sma:id":"144"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417090,
     "wof:geomhash":"e78ac078f0e5dce085cbd330c14e7bd6",
@@ -111,7 +116,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354772,
+    "wof:lastmodified":1695879567,
     "wof:name":"Zre\u010de",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/967/3/1108959673.geojson
+++ b/data/110/895/967/3/1108959673.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina \u017diri"
     ],
@@ -94,8 +97,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_147",
-        "eurostat:nuts_2021_id":"147"
+        "eurostat:nuts_2021_id":"147",
+        "svn-sma:id":"147"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417090,
     "wof:geomhash":"64db25ded093290d9fecd05d308a7304",
@@ -114,7 +119,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354772,
+    "wof:lastmodified":1695879567,
     "wof:name":"\u017diri",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/967/5/1108959675.geojson
+++ b/data/110/895/967/5/1108959675.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Dolenjske Toplice"
     ],
@@ -100,8 +103,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_157",
-        "eurostat:nuts_2021_id":"157"
+        "eurostat:nuts_2021_id":"157",
+        "svn-sma:id":"157"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417090,
     "wof:geomhash":"4ef8425bb21109e0ae4c7e9ddfe74fc8",
@@ -120,7 +125,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354772,
+    "wof:lastmodified":1695879567,
     "wof:name":"Dolenjske Toplice",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/967/7/1108959677.geojson
+++ b/data/110/895/967/7/1108959677.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Vuzenica"
     ],
@@ -133,8 +136,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_141",
-        "eurostat:nuts_2021_id":"141"
+        "eurostat:nuts_2021_id":"141",
+        "svn-sma:id":"141"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417091,
     "wof:geomhash":"9b81ef375b4aedc1c0fa37759da88861",
@@ -153,7 +158,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354772,
+    "wof:lastmodified":1695879568,
     "wof:name":"Vuzenica",
     "wof:parent_id":1108959955,
     "wof:placetype":"localadmin",

--- a/data/110/895/967/9/1108959679.geojson
+++ b/data/110/895/967/9/1108959679.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Lovrenc na Pohorju"
     ],
@@ -121,8 +124,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_167",
-        "eurostat:nuts_2021_id":"167"
+        "eurostat:nuts_2021_id":"167",
+        "svn-sma:id":"167"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417091,
     "wof:geomhash":"bf4bca646bcde11b6cc6a72395ef3f09",
@@ -141,7 +146,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354772,
+    "wof:lastmodified":1695879568,
     "wof:name":"Lovrenc na Pohorju",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/968/1/1108959681.geojson
+++ b/data/110/895/968/1/1108959681.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Vitanje"
     ],
@@ -124,8 +127,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_137",
-        "eurostat:nuts_2021_id":"137"
+        "eurostat:nuts_2021_id":"137",
+        "svn-sma:id":"137"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417091,
     "wof:geomhash":"6fda803800e47ffa6f619579ee1ee198",
@@ -144,7 +149,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354772,
+    "wof:lastmodified":1695879568,
     "wof:name":"Vitanje",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/968/3/1108959683.geojson
+++ b/data/110/895/968/3/1108959683.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Zagorje ob Savi"
     ],
@@ -151,8 +154,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_142",
-        "eurostat:nuts_2021_id":"142"
+        "eurostat:nuts_2021_id":"142",
+        "svn-sma:id":"142"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417091,
     "wof:geomhash":"d07a3dde1d3ff17bd5bdde8002c9e992",
@@ -171,7 +176,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354772,
+    "wof:lastmodified":1695879568,
     "wof:name":"Zagorje ob Savi",
     "wof:parent_id":1108959963,
     "wof:placetype":"localadmin",

--- a/data/110/895/968/5/1108959685.geojson
+++ b/data/110/895/968/5/1108959685.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Dobje"
     ],
@@ -85,8 +88,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_154",
-        "eurostat:nuts_2021_id":"154"
+        "eurostat:nuts_2021_id":"154",
+        "svn-sma:id":"154"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417092,
     "wof:geomhash":"18b07380a6b975349953805f0b55ba5a",
@@ -105,7 +110,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354773,
+    "wof:lastmodified":1695879568,
     "wof:name":"Dobje",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/968/9/1108959689.geojson
+++ b/data/110/895/968/9/1108959689.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Tr\u017ei\u010d"
     ],
@@ -121,8 +124,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_186",
-        "eurostat:nuts_2021_id":"186"
+        "eurostat:nuts_2021_id":"186",
+        "svn-sma:id":"186"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417092,
     "wof:geomhash":"5281c3b8110228650984c33cf3ea19c1",
@@ -141,7 +146,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354773,
+    "wof:lastmodified":1695879568,
     "wof:name":"Trzin",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/969/1/1108959691.geojson
+++ b/data/110/895/969/1/1108959691.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Dobrovnik"
     ],
@@ -146,8 +149,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_156",
-        "eurostat:nuts_2021_id":"156"
+        "eurostat:nuts_2021_id":"156",
+        "svn-sma:id":"156"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417092,
     "wof:geomhash":"7567200e2536f403f4701d036beff538",
@@ -166,7 +171,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354773,
+    "wof:lastmodified":1695879568,
     "wof:name":"Dobrovnik",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/969/3/1108959693.geojson
+++ b/data/110/895/969/3/1108959693.geojson
@@ -26,7 +26,10 @@
         "City Municipality of Celje"
     ],
     "label:eng_x_preferred_placetype":[
-        "city municipality"
+        "urban municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
     ],
     "label:slv_x_preferred_longname":[
         "Mestna ob\u010dina Celje"
@@ -238,8 +241,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_011",
-        "eurostat:nuts_2021_id":"011"
+        "eurostat:nuts_2021_id":"011",
+        "svn-sma:id":"011"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417092,
     "wof:geomhash":"ba4166d722742a0cabea265a1d375f42",
@@ -258,7 +263,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354773,
+    "wof:lastmodified":1695879568,
     "wof:name":"Celje",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/969/5/1108959695.geojson
+++ b/data/110/895/969/5/1108959695.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Prevalje"
     ],
@@ -148,8 +151,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_175",
-        "eurostat:nuts_2021_id":"175"
+        "eurostat:nuts_2021_id":"175",
+        "svn-sma:id":"175"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417093,
     "wof:geomhash":"7af8d70303a07bc85d4cba89ef01ca12",
@@ -168,7 +173,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354773,
+    "wof:lastmodified":1695879568,
     "wof:name":"Prevalje",
     "wof:parent_id":1108959955,
     "wof:placetype":"localadmin",

--- a/data/110/895/969/7/1108959697.geojson
+++ b/data/110/895/969/7/1108959697.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Velika Polana"
     ],
@@ -127,8 +130,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_187",
-        "eurostat:nuts_2021_id":"187"
+        "eurostat:nuts_2021_id":"187",
+        "svn-sma:id":"187"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417093,
     "wof:geomhash":"88bb22ecf80c5d178805b95c9e758b28",
@@ -147,7 +152,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354773,
+    "wof:lastmodified":1695879568,
     "wof:name":"Velika Polana",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/969/9/1108959699.geojson
+++ b/data/110/895/969/9/1108959699.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina \u010crnomelj"
     ],
@@ -139,8 +142,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_017",
-        "eurostat:nuts_2021_id":"017"
+        "eurostat:nuts_2021_id":"017",
+        "svn-sma:id":"017"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417093,
     "wof:geomhash":"b48544188603daa494569783a16d5dc2",
@@ -159,7 +164,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354773,
+    "wof:lastmodified":1695879568,
     "wof:name":"\u010crnomelj",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/970/1/1108959701.geojson
+++ b/data/110/895/970/1/1108959701.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina \u017delezniki"
     ],
@@ -91,8 +94,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_146",
-        "eurostat:nuts_2021_id":"146"
+        "eurostat:nuts_2021_id":"146",
+        "svn-sma:id":"146"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417093,
     "wof:geomhash":"874103fbda5e0cd801b0152c40559c7c",
@@ -111,7 +116,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354773,
+    "wof:lastmodified":1695879568,
     "wof:name":"\u017delezniki",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/970/3/1108959703.geojson
+++ b/data/110/895/970/3/1108959703.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Cerkvenjak"
     ],
@@ -121,8 +124,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_153",
-        "eurostat:nuts_2021_id":"153"
+        "eurostat:nuts_2021_id":"153",
+        "svn-sma:id":"153"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417094,
     "wof:geomhash":"5f468159cecf5589d292e07bc49bc7c3",
@@ -141,7 +146,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354773,
+    "wof:lastmodified":1695879568,
     "wof:name":"Cerkvenjak",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/970/7/1108959707.geojson
+++ b/data/110/895/970/7/1108959707.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Cankova"
     ],
@@ -133,8 +136,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_152",
-        "eurostat:nuts_2021_id":"152"
+        "eurostat:nuts_2021_id":"152",
+        "svn-sma:id":"152"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417094,
     "wof:geomhash":"686b7f4c70c72c31e41b4884fed39b32",
@@ -153,7 +158,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354774,
+    "wof:lastmodified":1695879569,
     "wof:name":"Cankova",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/970/9/1108959709.geojson
+++ b/data/110/895/970/9/1108959709.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Sveta Ana"
     ],
@@ -100,8 +103,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_181",
-        "eurostat:nuts_2021_id":"181"
+        "eurostat:nuts_2021_id":"181",
+        "svn-sma:id":"181"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417095,
     "wof:geomhash":"1c17497a117f5c3de261fb234eade994",
@@ -120,7 +125,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354774,
+    "wof:lastmodified":1695879569,
     "wof:name":"Sveta Ana",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/971/1/1108959711.geojson
+++ b/data/110/895/971/1/1108959711.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Kostel"
     ],
@@ -100,8 +103,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_165",
-        "eurostat:nuts_2021_id":"165"
+        "eurostat:nuts_2021_id":"165",
+        "svn-sma:id":"165"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417095,
     "wof:geomhash":"9bc7c58b1fedd565c0b80be459aece19",
@@ -120,7 +125,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354774,
+    "wof:lastmodified":1695879569,
     "wof:name":"Kostel",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/971/3/1108959713.geojson
+++ b/data/110/895/971/3/1108959713.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Prebold"
     ],
@@ -103,8 +106,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_174",
-        "eurostat:nuts_2021_id":"174"
+        "eurostat:nuts_2021_id":"174",
+        "svn-sma:id":"174"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417095,
     "wof:geomhash":"5d20d79b097a94d812b9d7f568af605b",
@@ -123,7 +128,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354774,
+    "wof:lastmodified":1695879569,
     "wof:name":"Prebold",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/971/5/1108959715.geojson
+++ b/data/110/895/971/5/1108959715.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Tabor"
     ],
@@ -157,8 +160,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_184",
-        "eurostat:nuts_2021_id":"184"
+        "eurostat:nuts_2021_id":"184",
+        "svn-sma:id":"184"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417095,
     "wof:geomhash":"e2d2708c47ce419d69bd3dfdbf4d2218",
@@ -177,7 +182,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354774,
+    "wof:lastmodified":1695879569,
     "wof:name":"Tabor",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/971/7/1108959717.geojson
+++ b/data/110/895/971/7/1108959717.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Trnovska vas"
     ],
@@ -79,8 +82,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_185",
-        "eurostat:nuts_2021_id":"185"
+        "eurostat:nuts_2021_id":"185",
+        "svn-sma:id":"185"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417095,
     "wof:geomhash":"a95a55bb739802e1395478c41536a8ed",
@@ -99,7 +104,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354774,
+    "wof:lastmodified":1695879569,
     "wof:name":"Trnovska vas",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/971/9/1108959719.geojson
+++ b/data/110/895/971/9/1108959719.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Gori\u0161nica"
     ],
@@ -91,8 +94,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_028",
-        "eurostat:nuts_2021_id":"028"
+        "eurostat:nuts_2021_id":"028",
+        "svn-sma:id":"028"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417096,
     "wof:geomhash":"fc82090c7728e09ac21f01a1732a6c10",
@@ -111,7 +116,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354774,
+    "wof:lastmodified":1695879569,
     "wof:name":"Gori\u0161nica",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/972/1/1108959721.geojson
+++ b/data/110/895/972/1/1108959721.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Polj\u010dane"
     ],
@@ -121,8 +124,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_200",
-        "eurostat:nuts_2021_id":"200"
+        "eurostat:nuts_2021_id":"200",
+        "svn-sma:id":"200"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417096,
     "wof:geomhash":"bae15a990f19477b3260260315299e6a",
@@ -141,7 +146,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354774,
+    "wof:lastmodified":1695879569,
     "wof:name":"Polj\u010dane",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/972/5/1108959725.geojson
+++ b/data/110/895/972/5/1108959725.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Sredi\u0161\u010de ob Dravi"
     ],
@@ -118,8 +121,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_202",
-        "eurostat:nuts_2021_id":"202"
+        "eurostat:nuts_2021_id":"202",
+        "svn-sma:id":"202"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417096,
     "wof:geomhash":"076bc7f8e4c0ee3c4067a310a5e7eaf9",
@@ -138,7 +143,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354774,
+    "wof:lastmodified":1695879569,
     "wof:name":"Sredi\u0161\u010de ob Dravi",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/972/7/1108959727.geojson
+++ b/data/110/895/972/7/1108959727.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Muta"
     ],
@@ -91,8 +94,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_081",
-        "eurostat:nuts_2021_id":"081"
+        "eurostat:nuts_2021_id":"081",
+        "svn-sma:id":"081"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417096,
     "wof:geomhash":"51570962867b157b58463c3620205280",
@@ -111,7 +116,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354774,
+    "wof:lastmodified":1695879569,
     "wof:name":"Muta",
     "wof:parent_id":1108959955,
     "wof:placetype":"localadmin",

--- a/data/110/895/972/9/1108959729.geojson
+++ b/data/110/895/972/9/1108959729.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina \u0160martno ob Paki"
     ],
@@ -124,8 +127,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_125",
-        "eurostat:nuts_2021_id":"125"
+        "eurostat:nuts_2021_id":"125",
+        "svn-sma:id":"125"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417097,
     "wof:geomhash":"5d133239a6c1776387221347e8016569",
@@ -144,7 +149,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354774,
+    "wof:lastmodified":1695879569,
     "wof:name":"\u0160martno ob Paki",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/973/1/1108959731.geojson
+++ b/data/110/895/973/1/1108959731.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina \u0160o\u0161tanj"
     ],
@@ -100,8 +103,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_126",
-        "eurostat:nuts_2021_id":"126"
+        "eurostat:nuts_2021_id":"126",
+        "svn-sma:id":"126"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417097,
     "wof:geomhash":"539eb7670ebc0b0990c897c78194c0bd",
@@ -120,7 +125,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354774,
+    "wof:lastmodified":1695879569,
     "wof:name":"\u0160o\u0161tanj",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/973/3/1108959733.geojson
+++ b/data/110/895/973/3/1108959733.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Ren\u010de - Vogrsko"
     ],
@@ -64,8 +67,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_201",
-        "eurostat:nuts_2021_id":"201"
+        "eurostat:nuts_2021_id":"201",
+        "svn-sma:id":"201"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417097,
     "wof:geomhash":"f0a35acba8be2876b17d54380893ca92",
@@ -84,7 +89,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354775,
+    "wof:lastmodified":1695879569,
     "wof:name":"Ren\u010de-Vogrsko",
     "wof:parent_id":1108959947,
     "wof:placetype":"localadmin",

--- a/data/110/895/973/5/1108959735.geojson
+++ b/data/110/895/973/5/1108959735.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Gorje"
     ],
@@ -64,8 +67,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_207",
-        "eurostat:nuts_2021_id":"207"
+        "eurostat:nuts_2021_id":"207",
+        "svn-sma:id":"207"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417097,
     "wof:geomhash":"ff6522b8af96a9e9c0b5b0c91091f287",
@@ -84,7 +89,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354775,
+    "wof:lastmodified":1695879569,
     "wof:name":"Gorje",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/973/7/1108959737.geojson
+++ b/data/110/895/973/7/1108959737.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Oplotnica"
     ],
@@ -127,8 +130,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_171",
-        "eurostat:nuts_2021_id":"171"
+        "eurostat:nuts_2021_id":"171",
+        "svn-sma:id":"171"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417097,
     "wof:geomhash":"547f0e66080e779344df9f8e4a03228f",
@@ -147,7 +152,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354775,
+    "wof:lastmodified":1695879569,
     "wof:name":"Oplotnica",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/973/9/1108959739.geojson
+++ b/data/110/895/973/9/1108959739.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Kidri\u010devo"
     ],
@@ -91,8 +94,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_045",
-        "eurostat:nuts_2021_id":"045"
+        "eurostat:nuts_2021_id":"045",
+        "svn-sma:id":"045"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417098,
     "wof:geomhash":"ad6334a8c34deb1f893899b04ff9329b",
@@ -111,7 +116,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354775,
+    "wof:lastmodified":1695879569,
     "wof:name":"Kidri\u010devo",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/974/3/1108959743.geojson
+++ b/data/110/895/974/3/1108959743.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Cirkulane"
     ],
@@ -115,8 +118,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_196",
-        "eurostat:nuts_2021_id":"196"
+        "eurostat:nuts_2021_id":"196",
+        "svn-sma:id":"196"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417098,
     "wof:geomhash":"2022a48c65a289ed8606ed1db318cdd5",
@@ -135,7 +140,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354775,
+    "wof:lastmodified":1695879569,
     "wof:name":"Cirkulane",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/974/5/1108959745.geojson
+++ b/data/110/895/974/5/1108959745.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina \u0160martno pri Litiji"
     ],
@@ -112,8 +115,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_194",
-        "eurostat:nuts_2021_id":"194"
+        "eurostat:nuts_2021_id":"194",
+        "svn-sma:id":"194"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417098,
     "wof:geomhash":"9145bfe9f07b220a538db145a33cf008",
@@ -132,7 +137,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354775,
+    "wof:lastmodified":1695879570,
     "wof:name":"\u0160martno pri Litiji",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/974/7/1108959747.geojson
+++ b/data/110/895/974/7/1108959747.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Videm"
     ],
@@ -115,8 +118,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_135",
-        "eurostat:nuts_2021_id":"135"
+        "eurostat:nuts_2021_id":"135",
+        "svn-sma:id":"135"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417099,
     "wof:geomhash":"e5122edcf24a1aa55ca92fdf4ab5f33f",
@@ -135,7 +140,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354775,
+    "wof:lastmodified":1695879570,
     "wof:name":"Videm",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/974/9/1108959749.geojson
+++ b/data/110/895/974/9/1108959749.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Ho\u010de - Slivnica"
     ],
@@ -64,8 +67,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_160",
-        "eurostat:nuts_2021_id":"160"
+        "eurostat:nuts_2021_id":"160",
+        "svn-sma:id":"160"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417099,
     "wof:geomhash":"b741528b8270542de8abd1774032de45",
@@ -84,7 +89,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354775,
+    "wof:lastmodified":1695879570,
     "wof:name":"Ho\u010de-Slivnica",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/975/1/1108959751.geojson
+++ b/data/110/895/975/1/1108959751.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Mirna Pe\u010d"
     ],
@@ -91,8 +94,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_170",
-        "eurostat:nuts_2021_id":"170"
+        "eurostat:nuts_2021_id":"170",
+        "svn-sma:id":"170"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417100,
     "wof:geomhash":"8c7ccb82ca64c06439500d9b89ae2db7",
@@ -111,7 +116,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354775,
+    "wof:lastmodified":1695879570,
     "wof:name":"Mirna Pe\u010d",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/975/3/1108959753.geojson
+++ b/data/110/895/975/3/1108959753.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Slovenske Konjice"
     ],
@@ -151,8 +154,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_114",
-        "eurostat:nuts_2021_id":"114"
+        "eurostat:nuts_2021_id":"114",
+        "svn-sma:id":"114"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417100,
     "wof:geomhash":"71f7fe8f6e1afd5f1fb438dafebc0d0d",
@@ -171,7 +176,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354775,
+    "wof:lastmodified":1695879570,
     "wof:name":"Slovenske Konjice",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/975/5/1108959755.geojson
+++ b/data/110/895/975/5/1108959755.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Destrnik"
     ],
@@ -97,8 +100,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_018",
-        "eurostat:nuts_2021_id":"018"
+        "eurostat:nuts_2021_id":"018",
+        "svn-sma:id":"018"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417100,
     "wof:geomhash":"9457b699a5685eda1c3068e7eb9fdf75",
@@ -117,7 +122,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354776,
+    "wof:lastmodified":1695879570,
     "wof:name":"Destrnik",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/975/7/1108959757.geojson
+++ b/data/110/895/975/7/1108959757.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Podlehnik"
     ],
@@ -130,8 +133,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_172",
-        "eurostat:nuts_2021_id":"172"
+        "eurostat:nuts_2021_id":"172",
+        "svn-sma:id":"172"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417101,
     "wof:geomhash":"c00ffa839538d472f12952d46b3a4376",
@@ -150,7 +155,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354776,
+    "wof:lastmodified":1695879570,
     "wof:name":"Podlehnik",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/976/1/1108959761.geojson
+++ b/data/110/895/976/1/1108959761.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Dornava"
     ],
@@ -97,8 +100,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_024",
-        "eurostat:nuts_2021_id":"024"
+        "eurostat:nuts_2021_id":"024",
+        "svn-sma:id":"024"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417101,
     "wof:geomhash":"c15c28bd985ad4ecbd5dbee1fe34b2df",
@@ -117,7 +122,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354776,
+    "wof:lastmodified":1695879570,
     "wof:name":"Dornava",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/976/3/1108959763.geojson
+++ b/data/110/895/976/3/1108959763.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Hajdina"
     ],
@@ -67,8 +70,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_159",
-        "eurostat:nuts_2021_id":"159"
+        "eurostat:nuts_2021_id":"159",
+        "svn-sma:id":"159"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417101,
     "wof:geomhash":"7554ba49208e3cf718d621ad0cf33c30",
@@ -87,7 +92,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354776,
+    "wof:lastmodified":1695879570,
     "wof:name":"Hajdina",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/976/5/1108959765.geojson
+++ b/data/110/895/976/5/1108959765.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Ormo\u017e"
     ],
@@ -112,8 +115,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_087",
-        "eurostat:nuts_2021_id":"087"
+        "eurostat:nuts_2021_id":"087",
+        "svn-sma:id":"087"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417101,
     "wof:geomhash":"746010cb1ba8c1df85cd73818a53d38e",
@@ -132,7 +137,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354776,
+    "wof:lastmodified":1695879570,
     "wof:name":"Ormo\u017e",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/976/7/1108959767.geojson
+++ b/data/110/895/976/7/1108959767.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina \u017detale"
     ],
@@ -88,8 +91,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_191",
-        "eurostat:nuts_2021_id":"191"
+        "eurostat:nuts_2021_id":"191",
+        "svn-sma:id":"191"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417101,
     "wof:geomhash":"c904892681d05c5c5a8435f45489700a",
@@ -108,7 +113,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354776,
+    "wof:lastmodified":1695879570,
     "wof:name":"\u017detale",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/976/9/1108959769.geojson
+++ b/data/110/895/976/9/1108959769.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Ribnica na Pohorju"
     ],
@@ -130,8 +133,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_177",
-        "eurostat:nuts_2021_id":"177"
+        "eurostat:nuts_2021_id":"177",
+        "svn-sma:id":"177"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417102,
     "wof:geomhash":"fb040c7e7d23bd457e8dfacc0bf6e6af",
@@ -150,7 +155,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354776,
+    "wof:lastmodified":1695879570,
     "wof:name":"Ribnica na Pohorju",
     "wof:parent_id":1108959955,
     "wof:placetype":"localadmin",

--- a/data/110/895/977/1/1108959771.geojson
+++ b/data/110/895/977/1/1108959771.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Ver\u017eej"
     ],
@@ -97,8 +100,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_188",
-        "eurostat:nuts_2021_id":"188"
+        "eurostat:nuts_2021_id":"188",
+        "svn-sma:id":"188"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417102,
     "wof:geomhash":"154d34d5a738d563656278972a7b1a52",
@@ -117,7 +122,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354776,
+    "wof:lastmodified":1695879570,
     "wof:name":"Ver\u017eej",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/977/3/1108959773.geojson
+++ b/data/110/895/977/3/1108959773.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Makole"
     ],
@@ -118,8 +121,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_198",
-        "eurostat:nuts_2021_id":"198"
+        "eurostat:nuts_2021_id":"198",
+        "svn-sma:id":"198"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417102,
     "wof:geomhash":"af4bb60bd768a04ebbaf3448d8cd1ce9",
@@ -138,7 +143,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354776,
+    "wof:lastmodified":1695879571,
     "wof:name":"Makole",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/977/5/1108959775.geojson
+++ b/data/110/895/977/5/1108959775.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Kri\u017eevci"
     ],
@@ -106,8 +109,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_166",
-        "eurostat:nuts_2021_id":"166"
+        "eurostat:nuts_2021_id":"166",
+        "svn-sma:id":"166"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417102,
     "wof:geomhash":"7f86ce4c94a8b55b5067d80db2de969a",
@@ -126,7 +131,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354776,
+    "wof:lastmodified":1695879571,
     "wof:name":"Kri\u017eevci",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/977/9/1108959779.geojson
+++ b/data/110/895/977/9/1108959779.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Markovci"
     ],
@@ -124,8 +127,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_168",
-        "eurostat:nuts_2021_id":"168"
+        "eurostat:nuts_2021_id":"168",
+        "svn-sma:id":"168"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417103,
     "wof:geomhash":"58882d80be0289d126918dbd3bb93c4a",
@@ -144,7 +149,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354777,
+    "wof:lastmodified":1695879571,
     "wof:name":"Markovci",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/978/1/1108959781.geojson
+++ b/data/110/895/978/1/1108959781.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Jur\u0161inci"
     ],
@@ -124,8 +127,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_042",
-        "eurostat:nuts_2021_id":"042"
+        "eurostat:nuts_2021_id":"042",
+        "svn-sma:id":"042"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417103,
     "wof:geomhash":"7da6714d2c4510000f19c8c34b3e8bae",
@@ -144,7 +149,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354777,
+    "wof:lastmodified":1695879571,
     "wof:name":"Jur\u0161inci",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/978/3/1108959783.geojson
+++ b/data/110/895/978/3/1108959783.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Star\u0161e"
     ],
@@ -121,8 +124,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_115",
-        "eurostat:nuts_2021_id":"115"
+        "eurostat:nuts_2021_id":"115",
+        "svn-sma:id":"115"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417103,
     "wof:geomhash":"159223ec6a7af1373b322c718ebd1715",
@@ -141,7 +146,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354777,
+    "wof:lastmodified":1695879571,
     "wof:name":"Star\u0161e",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/978/5/1108959785.geojson
+++ b/data/110/895/978/5/1108959785.geojson
@@ -26,7 +26,10 @@
         "City Municipality of Maribor"
     ],
     "label:eng_x_preferred_placetype":[
-        "city municipality"
+        "urban municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
     ],
     "label:slv_x_preferred_longname":[
         "Mestna ob\u010dina Maribor"
@@ -283,8 +286,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_070",
-        "eurostat:nuts_2021_id":"070"
+        "eurostat:nuts_2021_id":"070",
+        "svn-sma:id":"070"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417103,
     "wof:geomhash":"47f0c695457febfcb6853ae5a80d062f",
@@ -303,7 +308,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354777,
+    "wof:lastmodified":1695879571,
     "wof:name":"Maribor",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/978/7/1108959787.geojson
+++ b/data/110/895/978/7/1108959787.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina \u017du\u017eemberk"
     ],
@@ -133,8 +136,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_193",
-        "eurostat:nuts_2021_id":"193"
+        "eurostat:nuts_2021_id":"193",
+        "svn-sma:id":"193"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417104,
     "wof:geomhash":"17e9b7de92690cbc435b35cc5039b2dc",
@@ -153,7 +158,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354777,
+    "wof:lastmodified":1695879571,
     "wof:name":"\u017du\u017eemberk",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/978/9/1108959789.geojson
+++ b/data/110/895/978/9/1108959789.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Se\u017eana"
     ],
@@ -154,8 +157,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_111",
-        "eurostat:nuts_2021_id":"111"
+        "eurostat:nuts_2021_id":"111",
+        "svn-sma:id":"111"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417104,
     "wof:geomhash":"5f7ceb99e2320ddd79d2afd832c4f012",
@@ -174,7 +179,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354777,
+    "wof:lastmodified":1695879571,
     "wof:name":"Se\u017eana",
     "wof:parent_id":1108959951,
     "wof:placetype":"localadmin",

--- a/data/110/895/979/1/1108959791.geojson
+++ b/data/110/895/979/1/1108959791.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina \u0160entjur"
     ],
@@ -124,8 +127,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_120",
-        "eurostat:nuts_2021_id":"120"
+        "eurostat:nuts_2021_id":"120",
+        "svn-sma:id":"120"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417105,
     "wof:geomhash":"2c49331d9eadb2f5d8dc2ef9cf7c2e1f",
@@ -144,7 +149,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354777,
+    "wof:lastmodified":1695879571,
     "wof:name":"\u0160entjur",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/979/3/1108959793.geojson
+++ b/data/110/895/979/3/1108959793.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Stra\u017ea"
     ],
@@ -103,8 +106,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_203",
-        "eurostat:nuts_2021_id":"203"
+        "eurostat:nuts_2021_id":"203",
+        "svn-sma:id":"203"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417105,
     "wof:geomhash":"4ae3668fd7d6ec602d0f34c723a358a5",
@@ -123,7 +128,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354778,
+    "wof:lastmodified":1695879571,
     "wof:name":"Stra\u017ea",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/979/7/1108959797.geojson
+++ b/data/110/895/979/7/1108959797.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Bled"
     ],
@@ -193,8 +196,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_003",
-        "eurostat:nuts_2021_id":"003"
+        "eurostat:nuts_2021_id":"003",
+        "svn-sma:id":"003"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417105,
     "wof:geomhash":"b5bcd68dd2b243f8785213043cc018d8",
@@ -213,7 +218,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354778,
+    "wof:lastmodified":1695879571,
     "wof:name":"Bled",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/979/9/1108959799.geojson
+++ b/data/110/895/979/9/1108959799.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Dom\u017eale"
     ],
@@ -166,8 +169,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_023",
-        "eurostat:nuts_2021_id":"023"
+        "eurostat:nuts_2021_id":"023",
+        "svn-sma:id":"023"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417106,
     "wof:geomhash":"164e72c6d4646e70425c4569c8623767",
@@ -186,7 +191,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354778,
+    "wof:lastmodified":1695879571,
     "wof:name":"Dom\u017eale",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/980/1/1108959801.geojson
+++ b/data/110/895/980/1/1108959801.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Sveta Trojica v Slovenskih goricah"
     ],
@@ -64,8 +67,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_204",
-        "eurostat:nuts_2021_id":"204"
+        "eurostat:nuts_2021_id":"204",
+        "svn-sma:id":"204"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417108,
     "wof:geomhash":"7a86cb0cde2404b59eb7bddaa3dcad05",
@@ -84,7 +89,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354778,
+    "wof:lastmodified":1695879572,
     "wof:name":"Sveta Trojica v Slovenskih goricah",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/980/3/1108959803.geojson
+++ b/data/110/895/980/3/1108959803.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Roga\u0161ka Slatina"
     ],
@@ -118,8 +121,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_106",
-        "eurostat:nuts_2021_id":"106"
+        "eurostat:nuts_2021_id":"106",
+        "svn-sma:id":"106"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417108,
     "wof:geomhash":"f8b4931e7b6ced38e127ca6fb8ae36a3",
@@ -138,7 +143,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354778,
+    "wof:lastmodified":1695879572,
     "wof:name":"Roga\u0161ka Slatina",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/980/5/1108959805.geojson
+++ b/data/110/895/980/5/1108959805.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Sodra\u017eica"
     ],
@@ -97,8 +100,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_179",
-        "eurostat:nuts_2021_id":"179"
+        "eurostat:nuts_2021_id":"179",
+        "svn-sma:id":"179"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417108,
     "wof:geomhash":"457183d2d703fd18d128ec21f98a523d",
@@ -117,7 +122,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354778,
+    "wof:lastmodified":1695879572,
     "wof:name":"Sodra\u017eica",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/980/7/1108959807.geojson
+++ b/data/110/895/980/7/1108959807.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Lukovica"
     ],
@@ -70,8 +73,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_068",
-        "eurostat:nuts_2021_id":"068"
+        "eurostat:nuts_2021_id":"068",
+        "svn-sma:id":"068"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417108,
     "wof:geomhash":"bfe60fb44da62ef0df77f6c07b295605",
@@ -90,7 +95,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354778,
+    "wof:lastmodified":1695879572,
     "wof:name":"Lukovica",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/980/9/1108959809.geojson
+++ b/data/110/895/980/9/1108959809.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Re\u010dica ob Savinji"
     ],
@@ -112,8 +115,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_209",
-        "eurostat:nuts_2021_id":"209"
+        "eurostat:nuts_2021_id":"209",
+        "svn-sma:id":"209"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417109,
     "wof:geomhash":"3381779f6ec5040e12a2a30fe728e6db",
@@ -132,7 +137,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354779,
+    "wof:lastmodified":1695879572,
     "wof:name":"Re\u010dica ob Savinji",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/981/1/1108959811.geojson
+++ b/data/110/895/981/1/1108959811.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Brda"
     ],
@@ -112,8 +115,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_007",
-        "eurostat:nuts_2021_id":"007"
+        "eurostat:nuts_2021_id":"007",
+        "svn-sma:id":"007"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417109,
     "wof:geomhash":"b625e1fb29e8c2ddca21f76c3da61e8d",
@@ -132,7 +137,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354779,
+    "wof:lastmodified":1695879572,
     "wof:name":"Brda",
     "wof:parent_id":1108959947,
     "wof:placetype":"localadmin",

--- a/data/110/895/981/5/1108959815.geojson
+++ b/data/110/895/981/5/1108959815.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Sveti Jurij v Slovenskih goricah"
     ],
@@ -64,8 +67,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_210",
-        "eurostat:nuts_2021_id":"210"
+        "eurostat:nuts_2021_id":"210",
+        "svn-sma:id":"210"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417109,
     "wof:geomhash":"e60e83cbf6ba1dfad94a368b68941f23",
@@ -84,7 +89,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354779,
+    "wof:lastmodified":1695879572,
     "wof:name":"Sveti Jurij v Slovenskih goricah",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/981/7/1108959817.geojson
+++ b/data/110/895/981/7/1108959817.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Gornja Radgona"
     ],
@@ -151,8 +154,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_029",
-        "eurostat:nuts_2021_id":"029"
+        "eurostat:nuts_2021_id":"029",
+        "svn-sma:id":"029"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417109,
     "wof:geomhash":"ab69085c778c433312a496be3271d1fc",
@@ -171,7 +176,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354779,
+    "wof:lastmodified":1695879572,
     "wof:name":"Gornja Radgona",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/981/9/1108959819.geojson
+++ b/data/110/895/981/9/1108959819.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Bohinj"
     ],
@@ -97,8 +100,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_004",
-        "eurostat:nuts_2021_id":"004"
+        "eurostat:nuts_2021_id":"004",
+        "svn-sma:id":"004"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417110,
     "wof:geomhash":"15f40e30fafcc65dd5550b425e85bcd3",
@@ -117,7 +122,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354779,
+    "wof:lastmodified":1695879572,
     "wof:name":"Bohinj",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/982/1/1108959821.geojson
+++ b/data/110/895/982/1/1108959821.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina \u0160kofja Loka"
     ],
@@ -181,8 +184,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_122",
-        "eurostat:nuts_2021_id":"122"
+        "eurostat:nuts_2021_id":"122",
+        "svn-sma:id":"122"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417110,
     "wof:geomhash":"356fa89c4d53271b06b1b6b4bf1e91cc",
@@ -201,7 +206,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354779,
+    "wof:lastmodified":1695879572,
     "wof:name":"\u0160kofja Loka",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/982/3/1108959823.geojson
+++ b/data/110/895/982/3/1108959823.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina \u010cren\u0161ovci"
     ],
@@ -100,8 +103,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_015",
-        "eurostat:nuts_2021_id":"015"
+        "eurostat:nuts_2021_id":"015",
+        "svn-sma:id":"015"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417110,
     "wof:geomhash":"60ec33ab0cf6a80cd25a89d74582a6ed",
@@ -120,7 +125,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354779,
+    "wof:lastmodified":1695879572,
     "wof:name":"\u010cren\u0161ovci",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/982/5/1108959825.geojson
+++ b/data/110/895/982/5/1108959825.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Radovljica"
     ],
@@ -115,8 +118,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_102",
-        "eurostat:nuts_2021_id":"102"
+        "eurostat:nuts_2021_id":"102",
+        "svn-sma:id":"102"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417112,
     "wof:geomhash":"a6f046d10fd87147231477396bd26f4f",
@@ -135,7 +140,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354779,
+    "wof:lastmodified":1695879572,
     "wof:name":"Radovljica",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/982/7/1108959827.geojson
+++ b/data/110/895/982/7/1108959827.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Vransko"
     ],
@@ -112,8 +115,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_189",
-        "eurostat:nuts_2021_id":"189"
+        "eurostat:nuts_2021_id":"189",
+        "svn-sma:id":"189"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417112,
     "wof:geomhash":"c60dd74ad324d79289389cc031db844f",
@@ -132,7 +137,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354780,
+    "wof:lastmodified":1695879573,
     "wof:name":"Vransko",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/982/9/1108959829.geojson
+++ b/data/110/895/982/9/1108959829.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Benedikt"
     ],
@@ -100,8 +103,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_148",
-        "eurostat:nuts_2021_id":"148"
+        "eurostat:nuts_2021_id":"148",
+        "svn-sma:id":"148"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417113,
     "wof:geomhash":"23d277bbcd9096ea46f2985a63b7e0a4",
@@ -120,7 +125,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354780,
+    "wof:lastmodified":1695879573,
     "wof:name":"Benedikt",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/983/3/1108959833.geojson
+++ b/data/110/895/983/3/1108959833.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina \u0160marje\u0161ke Toplice"
     ],
@@ -109,8 +112,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_206",
-        "eurostat:nuts_2021_id":"206"
+        "eurostat:nuts_2021_id":"206",
+        "svn-sma:id":"206"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417113,
     "wof:geomhash":"6fcc04658e27467422976c261ea24e1f",
@@ -129,7 +134,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354780,
+    "wof:lastmodified":1695879573,
     "wof:name":"\u0160marje\u0161ke Toplice",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/983/5/1108959835.geojson
+++ b/data/110/895/983/5/1108959835.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Kostanjevica na Krki"
     ],
@@ -124,8 +127,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_197",
-        "eurostat:nuts_2021_id":"197"
+        "eurostat:nuts_2021_id":"197",
+        "svn-sma:id":"197"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417113,
     "wof:geomhash":"b93136c328381822877cb01352340a06",
@@ -144,7 +149,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354780,
+    "wof:lastmodified":1695879573,
     "wof:name":"Kostanjevica na Krki",
     "wof:parent_id":1108959965,
     "wof:placetype":"localadmin",

--- a/data/110/895/983/7/1108959837.geojson
+++ b/data/110/895/983/7/1108959837.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Komenda"
     ],
@@ -97,8 +100,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_164",
-        "eurostat:nuts_2021_id":"164"
+        "eurostat:nuts_2021_id":"164",
+        "svn-sma:id":"164"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417113,
     "wof:geomhash":"42296ccffd86623b116df897f48474ae",
@@ -117,7 +122,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354780,
+    "wof:lastmodified":1695879573,
     "wof:name":"Komenda",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/983/9/1108959839.geojson
+++ b/data/110/895/983/9/1108959839.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Trebnje"
     ],
@@ -127,8 +130,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_130",
-        "eurostat:nuts_2021_id":"130"
+        "eurostat:nuts_2021_id":"130",
+        "svn-sma:id":"130"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417114,
     "wof:geomhash":"4d1f08ab0d64d4a679481f7359699727",
@@ -147,7 +152,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354780,
+    "wof:lastmodified":1695879573,
     "wof:name":"Trebnje",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/984/1/1108959841.geojson
+++ b/data/110/895/984/1/1108959841.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina \u0160entrupert"
     ],
@@ -115,8 +118,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_211",
-        "eurostat:nuts_2021_id":"211"
+        "eurostat:nuts_2021_id":"211",
+        "svn-sma:id":"211"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417114,
     "wof:geomhash":"3cf6ba033367156fd2a39bf1686980fd",
@@ -135,7 +140,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354780,
+    "wof:lastmodified":1695879573,
     "wof:name":"\u0160entrupert",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/984/3/1108959843.geojson
+++ b/data/110/895/984/3/1108959843.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Kranjska Gora"
     ],
@@ -115,8 +118,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_053",
-        "eurostat:nuts_2021_id":"053"
+        "eurostat:nuts_2021_id":"053",
+        "svn-sma:id":"053"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417114,
     "wof:geomhash":"000389cfdf958d42af70304bab906b1e",
@@ -135,7 +140,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354780,
+    "wof:lastmodified":1695879573,
     "wof:name":"Kranjska Gora",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/984/5/1108959845.geojson
+++ b/data/110/895/984/5/1108959845.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Diva\u010da"
     ],
@@ -109,8 +112,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_019",
-        "eurostat:nuts_2021_id":"019"
+        "eurostat:nuts_2021_id":"019",
+        "svn-sma:id":"019"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417114,
     "wof:geomhash":"93502d0225e400381b607348c9acc211",
@@ -129,7 +134,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354780,
+    "wof:lastmodified":1695879573,
     "wof:name":"Diva\u010da",
     "wof:parent_id":1108959951,
     "wof:placetype":"localadmin",

--- a/data/110/895/984/7/1108959847.geojson
+++ b/data/110/895/984/7/1108959847.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Dobrova - Polhov Gradec"
     ],
@@ -73,8 +76,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_021",
-        "eurostat:nuts_2021_id":"021"
+        "eurostat:nuts_2021_id":"021",
+        "svn-sma:id":"021"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417115,
     "wof:geomhash":"80bf6901520baf6feefba6b4c96b67c9",
@@ -93,7 +98,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354781,
+    "wof:lastmodified":1695879573,
     "wof:name":"Dobrova-Polhov Gradec",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/985/1/1108959851.geojson
+++ b/data/110/895/985/1/1108959851.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Vrhnika"
     ],
@@ -142,8 +145,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_140",
-        "eurostat:nuts_2021_id":"140"
+        "eurostat:nuts_2021_id":"140",
+        "svn-sma:id":"140"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417115,
     "wof:geomhash":"db40dea7b9173e10d955d89370a9243e",
@@ -162,7 +167,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354781,
+    "wof:lastmodified":1695879573,
     "wof:name":"Vrhnika",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/985/3/1108959853.geojson
+++ b/data/110/895/985/3/1108959853.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Razkri\u017eje"
     ],
@@ -118,8 +121,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_176",
-        "eurostat:nuts_2021_id":"176"
+        "eurostat:nuts_2021_id":"176",
+        "svn-sma:id":"176"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417115,
     "wof:geomhash":"1b5ae631d57bcc50d3874ed87cc7b120",
@@ -138,7 +143,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354781,
+    "wof:lastmodified":1695879573,
     "wof:name":"Razkri\u017eje",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/985/5/1108959855.geojson
+++ b/data/110/895/985/5/1108959855.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Braslov\u010de"
     ],
@@ -118,8 +121,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_151",
-        "eurostat:nuts_2021_id":"151"
+        "eurostat:nuts_2021_id":"151",
+        "svn-sma:id":"151"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417116,
     "wof:geomhash":"c8f0b64fc412cc7e99e5d10bdd988622",
@@ -138,7 +143,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354781,
+    "wof:lastmodified":1695879573,
     "wof:name":"Braslov\u010de",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/985/7/1108959857.geojson
+++ b/data/110/895/985/7/1108959857.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Ankaran"
     ],
@@ -121,8 +124,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_213",
-        "eurostat:nuts_2021_id":"213"
+        "eurostat:nuts_2021_id":"213",
+        "svn-sma:id":"213"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417116,
     "wof:geomhash":"2bca83fb4811c317c9b572f0d193acc1",
@@ -141,7 +146,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354781,
+    "wof:lastmodified":1695879573,
     "wof:name":"Ankaran",
     "wof:parent_id":1108959951,
     "wof:placetype":"localadmin",

--- a/data/110/895/985/9/1108959859.geojson
+++ b/data/110/895/985/9/1108959859.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Velike La\u0161\u010de"
     ],
@@ -115,8 +118,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_134",
-        "eurostat:nuts_2021_id":"134"
+        "eurostat:nuts_2021_id":"134",
+        "svn-sma:id":"134"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417117,
     "wof:geomhash":"62a984b765ab94a414a80dbc0a2e7dbd",
@@ -135,7 +140,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354781,
+    "wof:lastmodified":1695879574,
     "wof:name":"Velike La\u0161\u010de",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/986/1/1108959861.geojson
+++ b/data/110/895/986/1/1108959861.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Dol pri Ljubljani"
     ],
@@ -94,8 +97,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_022",
-        "eurostat:nuts_2021_id":"022"
+        "eurostat:nuts_2021_id":"022",
+        "svn-sma:id":"022"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417117,
     "wof:geomhash":"f630fe8b5636fd007a7aa86bd79ee527",
@@ -114,7 +119,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354781,
+    "wof:lastmodified":1695879574,
     "wof:name":"Dol pri Ljubljani",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/986/3/1108959863.geojson
+++ b/data/110/895/986/3/1108959863.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Lo\u0161ka dolina"
     ],
@@ -64,8 +67,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_065",
-        "eurostat:nuts_2021_id":"065"
+        "eurostat:nuts_2021_id":"065",
+        "svn-sma:id":"065"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417117,
     "wof:geomhash":"1be5b083e9514345524544ec45bc053f",
@@ -84,7 +89,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354781,
+    "wof:lastmodified":1695879574,
     "wof:name":"Lo\u0161ka dolina",
     "wof:parent_id":1108959953,
     "wof:placetype":"localadmin",

--- a/data/110/895/986/5/1108959865.geojson
+++ b/data/110/895/986/5/1108959865.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Horjul"
     ],
@@ -67,8 +70,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_162",
-        "eurostat:nuts_2021_id":"162"
+        "eurostat:nuts_2021_id":"162",
+        "svn-sma:id":"162"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417117,
     "wof:geomhash":"346d14a3fd7df20fd9f904efc7162d4a",
@@ -87,7 +92,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354782,
+    "wof:lastmodified":1695879574,
     "wof:name":"Horjul",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/986/9/1108959869.geojson
+++ b/data/110/895/986/9/1108959869.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Mirna"
     ],
@@ -100,8 +103,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_212",
-        "eurostat:nuts_2021_id":"212"
+        "eurostat:nuts_2021_id":"212",
+        "svn-sma:id":"212"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417118,
     "wof:geomhash":"87c143cab97151dc53a38298f0b72d1d",
@@ -120,7 +125,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354782,
+    "wof:lastmodified":1695879574,
     "wof:name":"Mirna",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/987/1/1108959871.geojson
+++ b/data/110/895/987/1/1108959871.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Borovnica"
     ],
@@ -91,8 +94,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_005",
-        "eurostat:nuts_2021_id":"005"
+        "eurostat:nuts_2021_id":"005",
+        "svn-sma:id":"005"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417118,
     "wof:geomhash":"85f311ac159ed8aa38262ddddc298d2c",
@@ -111,7 +116,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354782,
+    "wof:lastmodified":1695879574,
     "wof:name":"Borovnica",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/987/3/1108959873.geojson
+++ b/data/110/895/987/3/1108959873.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Ilirska Bistrica"
     ],
@@ -151,8 +154,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_038",
-        "eurostat:nuts_2021_id":"038"
+        "eurostat:nuts_2021_id":"038",
+        "svn-sma:id":"038"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417118,
     "wof:geomhash":"73d499a6f83d1f6334a96b51701dcf6d",
@@ -171,7 +176,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354782,
+    "wof:lastmodified":1695879574,
     "wof:name":"Ilirska Bistrica",
     "wof:parent_id":1108959953,
     "wof:placetype":"localadmin",

--- a/data/110/895/987/5/1108959875.geojson
+++ b/data/110/895/987/5/1108959875.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Jesenice"
     ],
@@ -169,8 +172,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_041",
-        "eurostat:nuts_2021_id":"041"
+        "eurostat:nuts_2021_id":"041",
+        "svn-sma:id":"041"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417119,
     "wof:geomhash":"970e798eedf538f0a37e233a9908c168",
@@ -189,7 +194,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354782,
+    "wof:lastmodified":1695879574,
     "wof:name":"Jesenice",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/987/7/1108959877.geojson
+++ b/data/110/895/987/7/1108959877.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Log - Dragomer"
     ],
@@ -64,8 +67,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_208",
-        "eurostat:nuts_2021_id":"208"
+        "eurostat:nuts_2021_id":"208",
+        "svn-sma:id":"208"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417120,
     "wof:geomhash":"109f99602bee3f44188396deda682012",
@@ -84,7 +89,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354782,
+    "wof:lastmodified":1695879574,
     "wof:name":"Log-Dragomer",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/987/9/1108959879.geojson
+++ b/data/110/895/987/9/1108959879.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina La\u0161ko"
     ],
@@ -109,8 +112,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_057",
-        "eurostat:nuts_2021_id":"057"
+        "eurostat:nuts_2021_id":"057",
+        "svn-sma:id":"057"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417120,
     "wof:geomhash":"db2d10b11e8f2d3b39476acf8a48b34f",
@@ -129,7 +134,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354782,
+    "wof:lastmodified":1695879574,
     "wof:name":"La\u0161ko",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/988/1/1108959881.geojson
+++ b/data/110/895/988/1/1108959881.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Medvode"
     ],
@@ -145,8 +148,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_071",
-        "eurostat:nuts_2021_id":"071"
+        "eurostat:nuts_2021_id":"071",
+        "svn-sma:id":"071"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417120,
     "wof:geomhash":"1f13922ee5f2ed31e3adae9dc2e04c4d",
@@ -165,7 +170,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354782,
+    "wof:lastmodified":1695879574,
     "wof:name":"Medvode",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/988/3/1108959883.geojson
+++ b/data/110/895/988/3/1108959883.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Rade\u010de"
     ],
@@ -136,8 +139,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_099",
-        "eurostat:nuts_2021_id":"099"
+        "eurostat:nuts_2021_id":"099",
+        "svn-sma:id":"099"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417121,
     "wof:geomhash":"0f1ad74808307aa9deebf8c593deb304",
@@ -156,7 +161,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354783,
+    "wof:lastmodified":1695879574,
     "wof:name":"Rade\u010de",
     "wof:parent_id":1108959965,
     "wof:placetype":"localadmin",

--- a/data/110/895/988/7/1108959887.geojson
+++ b/data/110/895/988/7/1108959887.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Ig"
     ],
@@ -67,8 +70,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_037",
-        "eurostat:nuts_2021_id":"037"
+        "eurostat:nuts_2021_id":"037",
+        "svn-sma:id":"037"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417121,
     "wof:geomhash":"e10cac68b7b70d3f63ea8b6253cd5998",
@@ -87,7 +92,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354783,
+    "wof:lastmodified":1695879574,
     "wof:name":"Ig",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/988/9/1108959889.geojson
+++ b/data/110/895/988/9/1108959889.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Logatec"
     ],
@@ -103,8 +106,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_064",
-        "eurostat:nuts_2021_id":"064"
+        "eurostat:nuts_2021_id":"064",
+        "svn-sma:id":"064"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417121,
     "wof:geomhash":"4ff37b5f13839e9088414ece236e8e3e",
@@ -123,7 +128,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354783,
+    "wof:lastmodified":1695879574,
     "wof:name":"Logatec",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/989/1/1108959891.geojson
+++ b/data/110/895/989/1/1108959891.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina \u0160kofljica"
     ],
@@ -88,8 +91,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_123",
-        "eurostat:nuts_2021_id":"123"
+        "eurostat:nuts_2021_id":"123",
+        "svn-sma:id":"123"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417121,
     "wof:geomhash":"bd21497c290fa9d8911b23bf445114c3",
@@ -108,7 +113,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354783,
+    "wof:lastmodified":1695879575,
     "wof:name":"\u0160kofljica",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/989/3/1108959893.geojson
+++ b/data/110/895/989/3/1108959893.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Bloke"
     ],
@@ -67,8 +70,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_150",
-        "eurostat:nuts_2021_id":"150"
+        "eurostat:nuts_2021_id":"150",
+        "svn-sma:id":"150"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417122,
     "wof:geomhash":"cdbc7ad2734e4d0483876b97618acd7b",
@@ -87,7 +92,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354783,
+    "wof:lastmodified":1695879575,
     "wof:name":"Bloke",
     "wof:parent_id":1108959953,
     "wof:placetype":"localadmin",

--- a/data/110/895/989/5/1108959895.geojson
+++ b/data/110/895/989/5/1108959895.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Brezovica"
     ],
@@ -121,8 +124,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_008",
-        "eurostat:nuts_2021_id":"008"
+        "eurostat:nuts_2021_id":"008",
+        "svn-sma:id":"008"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417122,
     "wof:geomhash":"3aa2fa6cb07546e41e5200801e9b3aba",
@@ -141,7 +146,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354783,
+    "wof:lastmodified":1695879575,
     "wof:name":"Brezovica",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/989/7/1108959897.geojson
+++ b/data/110/895/989/7/1108959897.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Gorenja vas - Poljane"
     ],
@@ -73,8 +76,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_027",
-        "eurostat:nuts_2021_id":"027"
+        "eurostat:nuts_2021_id":"027",
+        "svn-sma:id":"027"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417122,
     "wof:geomhash":"d49b67b6079c533c9ea588d68e2a94ef",
@@ -93,7 +98,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354783,
+    "wof:lastmodified":1695879575,
     "wof:name":"Gorenja vas-Poljane",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/989/9/1108959899.geojson
+++ b/data/110/895/989/9/1108959899.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina \u017dirovnica"
     ],
@@ -82,8 +85,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_192",
-        "eurostat:nuts_2021_id":"192"
+        "eurostat:nuts_2021_id":"192",
+        "svn-sma:id":"192"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417123,
     "wof:geomhash":"175136187ed40247fba9745da3b2bee8",
@@ -102,7 +107,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354783,
+    "wof:lastmodified":1695879575,
     "wof:name":"\u017dirovnica",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/990/1/1108959901.geojson
+++ b/data/110/895/990/1/1108959901.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Nazarje"
     ],
@@ -100,8 +103,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_083",
-        "eurostat:nuts_2021_id":"083"
+        "eurostat:nuts_2021_id":"083",
+        "svn-sma:id":"083"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417123,
     "wof:geomhash":"b244fef2dc0e103651d18c1cb5c39e6c",
@@ -120,7 +125,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354783,
+    "wof:lastmodified":1695879575,
     "wof:name":"Nazarje",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/990/5/1108959905.geojson
+++ b/data/110/895/990/5/1108959905.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Cerknica"
     ],
@@ -154,8 +157,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_013",
-        "eurostat:nuts_2021_id":"013"
+        "eurostat:nuts_2021_id":"013",
+        "svn-sma:id":"013"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417123,
     "wof:geomhash":"5eca9754e27a314a32c36255f2b86215",
@@ -174,7 +179,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354784,
+    "wof:lastmodified":1695879575,
     "wof:name":"Cerknica",
     "wof:parent_id":1108959953,
     "wof:placetype":"localadmin",

--- a/data/110/895/990/7/1108959907.geojson
+++ b/data/110/895/990/7/1108959907.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Litija"
     ],
@@ -109,8 +112,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_060",
-        "eurostat:nuts_2021_id":"060"
+        "eurostat:nuts_2021_id":"060",
+        "svn-sma:id":"060"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417123,
     "wof:geomhash":"0662527b01dc5d8a1db315c600c17272",
@@ -129,7 +134,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354784,
+    "wof:lastmodified":1695879576,
     "wof:name":"Litija",
     "wof:parent_id":1108959963,
     "wof:placetype":"localadmin",

--- a/data/110/895/990/9/1108959909.geojson
+++ b/data/110/895/990/9/1108959909.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Metlika"
     ],
@@ -139,8 +142,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_073",
-        "eurostat:nuts_2021_id":"073"
+        "eurostat:nuts_2021_id":"073",
+        "svn-sma:id":"073"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417124,
     "wof:geomhash":"707281fe13f479ae37281ccb83cdf8b8",
@@ -159,7 +164,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354784,
+    "wof:lastmodified":1695879576,
     "wof:name":"Metlika",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/991/1/1108959911.geojson
+++ b/data/110/895/991/1/1108959911.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Trbovlje"
     ],
@@ -172,8 +175,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_129",
-        "eurostat:nuts_2021_id":"129"
+        "eurostat:nuts_2021_id":"129",
+        "svn-sma:id":"129"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417124,
     "wof:geomhash":"4334b91445ef72e268dd27b84e516705",
@@ -192,7 +197,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354784,
+    "wof:lastmodified":1695879576,
     "wof:name":"Trbovlje",
     "wof:parent_id":1108959963,
     "wof:placetype":"localadmin",

--- a/data/110/895/991/3/1108959913.geojson
+++ b/data/110/895/991/3/1108959913.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Mokronog - Trebelno"
     ],
@@ -64,8 +67,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_199",
-        "eurostat:nuts_2021_id":"199"
+        "eurostat:nuts_2021_id":"199",
+        "svn-sma:id":"199"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417124,
     "wof:geomhash":"3beb241d41954942e5c79839f9d98ff4",
@@ -84,7 +89,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354784,
+    "wof:lastmodified":1695879576,
     "wof:name":"Mokronog-Trebelno",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/991/5/1108959915.geojson
+++ b/data/110/895/991/5/1108959915.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Bistrica ob Sotli"
     ],
@@ -124,8 +127,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_149",
-        "eurostat:nuts_2021_id":"149"
+        "eurostat:nuts_2021_id":"149",
+        "svn-sma:id":"149"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417124,
     "wof:geomhash":"e4b74e49193cc13785815cba2ca7853f",
@@ -144,7 +149,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354784,
+    "wof:lastmodified":1695879576,
     "wof:name":"Bistrica ob Sotli",
     "wof:parent_id":1108959965,
     "wof:placetype":"localadmin",

--- a/data/110/895/991/7/1108959917.geojson
+++ b/data/110/895/991/7/1108959917.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Trzin"
     ],
@@ -133,8 +136,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_131",
-        "eurostat:nuts_2021_id":"131"
+        "eurostat:nuts_2021_id":"131",
+        "svn-sma:id":"131"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417125,
     "wof:geomhash":"29d47cfb1d6ee87a7380ef1adee5410a",
@@ -153,7 +158,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354784,
+    "wof:lastmodified":1695879576,
     "wof:name":"Tr\u017ei\u010d",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/991/9/1108959919.geojson
+++ b/data/110/895/991/9/1108959919.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Ko\u010devje"
     ],
@@ -115,8 +118,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_048",
-        "eurostat:nuts_2021_id":"048"
+        "eurostat:nuts_2021_id":"048",
+        "svn-sma:id":"048"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417125,
     "wof:geomhash":"2b59a745578e4fb87596822df0d6635b",
@@ -135,7 +140,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354785,
+    "wof:lastmodified":1695879576,
     "wof:name":"Ko\u010devje",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/992/3/1108959923.geojson
+++ b/data/110/895/992/3/1108959923.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Vodice"
     ],
@@ -127,8 +130,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_138",
-        "eurostat:nuts_2021_id":"138"
+        "eurostat:nuts_2021_id":"138",
+        "svn-sma:id":"138"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417125,
     "wof:geomhash":"9c4a2fc87fb8b676e85d8916cb99f8a3",
@@ -147,7 +152,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354785,
+    "wof:lastmodified":1695879576,
     "wof:name":"Vodice",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/992/5/1108959925.geojson
+++ b/data/110/895/992/5/1108959925.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Moravske Toplice"
     ],
@@ -121,8 +124,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_078",
-        "eurostat:nuts_2021_id":"078"
+        "eurostat:nuts_2021_id":"078",
+        "svn-sma:id":"078"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417126,
     "wof:geomhash":"6d0b6d1ded4fb54aad600210a958d33d",
@@ -141,7 +146,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354785,
+    "wof:lastmodified":1695879577,
     "wof:name":"Moravske Toplice",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/992/7/1108959927.geojson
+++ b/data/110/895/992/7/1108959927.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Sevnica"
     ],
@@ -145,8 +148,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_110",
-        "eurostat:nuts_2021_id":"110"
+        "eurostat:nuts_2021_id":"110",
+        "svn-sma:id":"110"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417127,
     "wof:geomhash":"8879facb8ea2acd4176aa41ef9bd32de",
@@ -165,7 +170,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354785,
+    "wof:lastmodified":1695879577,
     "wof:name":"Sevnica",
     "wof:parent_id":1108959965,
     "wof:placetype":"localadmin",

--- a/data/110/895/992/9/1108959929.geojson
+++ b/data/110/895/992/9/1108959929.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina \u017dalec"
     ],
@@ -139,8 +142,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_190",
-        "eurostat:nuts_2021_id":"190"
+        "eurostat:nuts_2021_id":"190",
+        "svn-sma:id":"190"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417128,
     "wof:geomhash":"5adc88de05df2e97c805d6d921c38664",
@@ -159,7 +164,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354785,
+    "wof:lastmodified":1695879577,
     "wof:name":"\u017dalec",
     "wof:parent_id":1108959959,
     "wof:placetype":"localadmin",

--- a/data/110/895/993/1/1108959931.geojson
+++ b/data/110/895/993/1/1108959931.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Sveti Toma\u017e"
     ],
@@ -70,8 +73,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_205",
-        "eurostat:nuts_2021_id":"205"
+        "eurostat:nuts_2021_id":"205",
+        "svn-sma:id":"205"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417128,
     "wof:geomhash":"255fe2cce06098f15ee779f5832109e5",
@@ -90,7 +95,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354785,
+    "wof:lastmodified":1695879577,
     "wof:name":"Sveti Toma\u017e",
     "wof:parent_id":1108959961,
     "wof:placetype":"localadmin",

--- a/data/110/895/993/3/1108959933.geojson
+++ b/data/110/895/993/3/1108959933.geojson
@@ -26,7 +26,10 @@
         "City Municipality of Kranj"
     ],
     "label:eng_x_preferred_placetype":[
-        "city municipality"
+        "urban municipality"
+    ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
     ],
     "label:slv_x_preferred_longname":[
         "Mestna ob\u010dina Kranj"
@@ -232,8 +235,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_052",
-        "eurostat:nuts_2021_id":"052"
+        "eurostat:nuts_2021_id":"052",
+        "svn-sma:id":"052"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417128,
     "wof:geomhash":"1667d5e8bc9261aeaa0a2c98bdfb0fb4",
@@ -252,7 +257,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354785,
+    "wof:lastmodified":1695879577,
     "wof:name":"Kranj",
     "wof:parent_id":1108959967,
     "wof:placetype":"localadmin",

--- a/data/110/895/993/5/1108959935.geojson
+++ b/data/110/895/993/5/1108959935.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Puconci"
     ],
@@ -142,8 +145,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_097",
-        "eurostat:nuts_2021_id":"097"
+        "eurostat:nuts_2021_id":"097",
+        "svn-sma:id":"097"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417128,
     "wof:geomhash":"549afcf9af1b871cf7922769aa2c99fd",
@@ -162,7 +167,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354785,
+    "wof:lastmodified":1695879577,
     "wof:name":"Puconci",
     "wof:parent_id":1108959945,
     "wof:placetype":"localadmin",

--- a/data/110/895/993/7/1108959937.geojson
+++ b/data/110/895/993/7/1108959937.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina \u0160entjernej"
     ],
@@ -124,8 +127,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_119",
-        "eurostat:nuts_2021_id":"119"
+        "eurostat:nuts_2021_id":"119",
+        "svn-sma:id":"119"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417129,
     "wof:geomhash":"f2badf481621b949170fb2ac81317d15",
@@ -144,7 +149,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354786,
+    "wof:lastmodified":1695879577,
     "wof:name":"\u0160entjernej",
     "wof:parent_id":1108959943,
     "wof:placetype":"localadmin",

--- a/data/110/895/994/1/1108959941.geojson
+++ b/data/110/895/994/1/1108959941.geojson
@@ -28,6 +28,9 @@
     "label:eng_x_preferred_placetype":[
         "municipality"
     ],
+    "label:fra_x_preferred_placetype":[
+        "commune"
+    ],
     "label:slv_x_preferred_longname":[
         "Ob\u010dina Kamnik"
     ],
@@ -181,8 +184,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "eg:gisco_id":"SI_043",
-        "eurostat:nuts_2021_id":"043"
+        "eurostat:nuts_2021_id":"043",
+        "svn-sma:id":"043"
     },
+    "wof:concordances_official":"svn-sma:id",
     "wof:country":"SI",
     "wof:created":1493417129,
     "wof:geomhash":"19f187b87cd8c3a35a05644cc2a0548f",
@@ -201,7 +206,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684354786,
+    "wof:lastmodified":1695879577,
     "wof:name":"Kamnik",
     "wof:parent_id":1108959949,
     "wof:placetype":"localadmin",

--- a/data/110/895/994/3/1108959943.geojson
+++ b/data/110/895/994/3/1108959943.geojson
@@ -90,8 +90,14 @@
     "wof:concordances":{
         "eurostat:nuts_2021_id":"SI037",
         "hasc:id":"SI.DO",
-        "iso:id":"7"
+        "iso:code_historic":"SI-07",
+        "iso:id":"7",
+        "svn-sma:id":"07"
     },
+    "wof:concordances_official":"svn-sma:id",
+    "wof:concordances_official_alt":[
+        "iso:code_historic"
+    ],
     "wof:country":"SI",
     "wof:created":1493419738,
     "wof:geomhash":"9b57a3af810cbbc557ccb9ea7260dee5",
@@ -109,7 +115,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684351673,
+    "wof:lastmodified":1695885317,
     "wof:name":"Jugovzhodna Slovenija",
     "wof:parent_id":85633779,
     "wof:placetype":"region",

--- a/data/110/895/994/5/1108959945.geojson
+++ b/data/110/895/994/5/1108959945.geojson
@@ -90,8 +90,14 @@
     "wof:concordances":{
         "eurostat:nuts_2021_id":"SI031",
         "hasc:id":"SI.PM",
-        "iso:id":"1"
+        "iso:code_historic":"SI-01",
+        "iso:id":"1",
+        "svn-sma:id":"01"
     },
+    "wof:concordances_official":"svn-sma:id",
+    "wof:concordances_official_alt":[
+        "iso:code_historic"
+    ],
     "wof:country":"SI",
     "wof:created":1493419739,
     "wof:geomhash":"e514e9f70fe8d4f27a59cc8217ae2d36",
@@ -109,7 +115,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684351673,
+    "wof:lastmodified":1695885317,
     "wof:name":"Pomurska",
     "wof:parent_id":85633779,
     "wof:placetype":"region",

--- a/data/110/895/994/7/1108959947.geojson
+++ b/data/110/895/994/7/1108959947.geojson
@@ -114,8 +114,14 @@
     "wof:concordances":{
         "eurostat:nuts_2021_id":"SI043",
         "hasc:id":"SI.SP",
-        "iso:id":"11"
+        "iso:code_historic":"SI-11",
+        "iso:id":"11",
+        "svn-sma:id":"11"
     },
+    "wof:concordances_official":"svn-sma:id",
+    "wof:concordances_official_alt":[
+        "iso:code_historic"
+    ],
     "wof:country":"SI",
     "wof:created":1493419739,
     "wof:geomhash":"952bb94eec0c1153b55becb557110e02",
@@ -133,7 +139,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684351674,
+    "wof:lastmodified":1695885318,
     "wof:name":"Gori\u0161ka",
     "wof:parent_id":85633779,
     "wof:placetype":"region",

--- a/data/110/895/994/9/1108959949.geojson
+++ b/data/110/895/994/9/1108959949.geojson
@@ -90,8 +90,14 @@
     "wof:concordances":{
         "eurostat:nuts_2021_id":"SI041",
         "hasc:id":"SI.LJ",
-        "iso:id":"8"
+        "iso:code_historic":"SI-08",
+        "iso:id":"8",
+        "svn-sma:id":"08"
     },
+    "wof:concordances_official":"svn-sma:id",
+    "wof:concordances_official_alt":[
+        "iso:code_historic"
+    ],
     "wof:country":"SI",
     "wof:created":1493419740,
     "wof:geomhash":"49b34d91dbbd0cf0b0d64bd8959b25ee",
@@ -109,7 +115,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684351674,
+    "wof:lastmodified":1695885318,
     "wof:name":"Osrednjeslovenska",
     "wof:parent_id":85633779,
     "wof:placetype":"region",

--- a/data/110/895/995/1/1108959951.geojson
+++ b/data/110/895/995/1/1108959951.geojson
@@ -90,8 +90,14 @@
     "wof:concordances":{
         "eurostat:nuts_2021_id":"SI044",
         "hasc:id":"SI.JP",
-        "iso:id":"12"
+        "iso:code_historic":"SI-12",
+        "iso:id":"12",
+        "svn-sma:id":"12"
     },
+    "wof:concordances_official":"svn-sma:id",
+    "wof:concordances_official_alt":[
+        "iso:code_historic"
+    ],
     "wof:country":"SI",
     "wof:created":1493419741,
     "wof:geomhash":"0480e3f8dd9da6b0470dc9b7aeeb6323",
@@ -109,7 +115,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684351674,
+    "wof:lastmodified":1695885318,
     "wof:name":"Obalno-kra\u0161ka",
     "wof:parent_id":85633779,
     "wof:placetype":"region",

--- a/data/110/895/995/3/1108959953.geojson
+++ b/data/110/895/995/3/1108959953.geojson
@@ -90,8 +90,14 @@
     "wof:concordances":{
         "eurostat:nuts_2021_id":"SI038",
         "hasc:id":"SI.NO",
-        "iso:id":"10"
+        "iso:code_historic":"SI-10",
+        "iso:id":"10",
+        "svn-sma:id":"10"
     },
+    "wof:concordances_official":"svn-sma:id",
+    "wof:concordances_official_alt":[
+        "iso:code_historic"
+    ],
     "wof:country":"SI",
     "wof:created":1493419741,
     "wof:geomhash":"6b5538c6d5d3ed96c56b2a8faf93f4e3",
@@ -109,7 +115,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684351675,
+    "wof:lastmodified":1695885319,
     "wof:name":"Primorsko-notranjska",
     "wof:parent_id":85633779,
     "wof:placetype":"region",

--- a/data/110/895/995/5/1108959955.geojson
+++ b/data/110/895/995/5/1108959955.geojson
@@ -81,8 +81,14 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
-        "eurostat:nuts_2021_id":"SI033"
+        "eurostat:nuts_2021_id":"SI033",
+        "iso:code_historic":"SI-03",
+        "svn-sma:id":"03"
     },
+    "wof:concordances_official":"svn-sma:id",
+    "wof:concordances_official_alt":[
+        "iso:code_historic"
+    ],
     "wof:country":"SI",
     "wof:created":1493419742,
     "wof:geomhash":"07eb4269910a512511494897785d1e82",
@@ -100,7 +106,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684351675,
+    "wof:lastmodified":1695885319,
     "wof:name":"Koro\u0161ka",
     "wof:parent_id":85633779,
     "wof:placetype":"region",

--- a/data/110/895/995/9/1108959959.geojson
+++ b/data/110/895/995/9/1108959959.geojson
@@ -90,8 +90,14 @@
     "wof:concordances":{
         "eurostat:nuts_2021_id":"SI034",
         "hasc:id":"SI.SA",
-        "iso:id":"4"
+        "iso:code_historic":"SI-04",
+        "iso:id":"4",
+        "svn-sma:id":"04"
     },
+    "wof:concordances_official":"svn-sma:id",
+    "wof:concordances_official_alt":[
+        "iso:code_historic"
+    ],
     "wof:country":"SI",
     "wof:created":1493419742,
     "wof:geomhash":"b1ed1dccb9d87d591511ff1a1eb00a4a",
@@ -109,7 +115,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684351675,
+    "wof:lastmodified":1695885319,
     "wof:name":"Savinjska",
     "wof:parent_id":85633779,
     "wof:placetype":"region",

--- a/data/110/895/996/1/1108959961.geojson
+++ b/data/110/895/996/1/1108959961.geojson
@@ -90,8 +90,14 @@
     "wof:concordances":{
         "eurostat:nuts_2021_id":"SI032",
         "hasc:id":"SI.PD",
-        "iso:id":"2"
+        "iso:code_historic":"SI-02",
+        "iso:id":"2",
+        "svn-sma:id":"02"
     },
+    "wof:concordances_official":"svn-sma:id",
+    "wof:concordances_official_alt":[
+        "iso:code_historic"
+    ],
     "wof:country":"SI",
     "wof:created":1493419743,
     "wof:geomhash":"16d80179b102778507f9ae1fe16e7585",
@@ -109,7 +115,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684351675,
+    "wof:lastmodified":1695885320,
     "wof:name":"Podravska",
     "wof:parent_id":85633779,
     "wof:placetype":"region",

--- a/data/110/895/996/3/1108959963.geojson
+++ b/data/110/895/996/3/1108959963.geojson
@@ -135,8 +135,14 @@
     "wof:concordances":{
         "eurostat:nuts_2021_id":"SI035",
         "hasc:id":"SI.ZS",
-        "iso:id":"5"
+        "iso:code_historic":"SI-05",
+        "iso:id":"5",
+        "svn-sma:id":"05"
     },
+    "wof:concordances_official":"svn-sma:id",
+    "wof:concordances_official_alt":[
+        "iso:code_historic"
+    ],
     "wof:country":"SI",
     "wof:created":1493419744,
     "wof:geomhash":"5a185416cd3e92b4d4a7069f80181a65",
@@ -154,7 +160,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684351676,
+    "wof:lastmodified":1695885320,
     "wof:name":"Zasavska",
     "wof:parent_id":85633779,
     "wof:placetype":"region",

--- a/data/110/895/996/5/1108959965.geojson
+++ b/data/110/895/996/5/1108959965.geojson
@@ -90,8 +90,14 @@
     "wof:concordances":{
         "eurostat:nuts_2021_id":"SI036",
         "hasc:id":"SI.PS",
-        "iso:id":"6"
+        "iso:code_historic":"SI-06",
+        "iso:id":"6",
+        "svn-sma:id":"06"
     },
+    "wof:concordances_official":"svn-sma:id",
+    "wof:concordances_official_alt":[
+        "iso:code_historic"
+    ],
     "wof:country":"SI",
     "wof:created":1493419744,
     "wof:geomhash":"e6b72bb28f216de1d8e68f2b2d788a61",
@@ -109,7 +115,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684351676,
+    "wof:lastmodified":1695885320,
     "wof:name":"Posavska",
     "wof:parent_id":85633779,
     "wof:placetype":"region",

--- a/data/110/895/996/7/1108959967.geojson
+++ b/data/110/895/996/7/1108959967.geojson
@@ -90,8 +90,14 @@
     "wof:concordances":{
         "eurostat:nuts_2021_id":"SI042",
         "hasc:id":"SI.GO",
-        "iso:id":"9"
+        "iso:code_historic":"SI-09",
+        "iso:id":"9",
+        "svn-sma:id":"09"
     },
+    "wof:concordances_official":"svn-sma:id",
+    "wof:concordances_official_alt":[
+        "iso:code_historic"
+    ],
     "wof:country":"SI",
     "wof:created":1493419745,
     "wof:geomhash":"24a177644aa361d42c2a02742afb7809",
@@ -109,7 +115,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1684351676,
+    "wof:lastmodified":1695885321,
     "wof:name":"Gorenjska",
     "wof:parent_id":85633779,
     "wof:placetype":"region",

--- a/data/856/337/79/85633779.geojson
+++ b/data/856/337/79/85633779.geojson
@@ -1219,6 +1219,7 @@
         "hasc:id":"SI",
         "icao:code":"S5",
         "ioc:id":"SLO",
+        "iso:code":"SI",
         "itu:id":"SVN",
         "loc:id":"n81035365",
         "m49:code":"705",
@@ -1233,6 +1234,7 @@
         "wk:page":"Slovenia",
         "wmo:id":"LJ"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SI",
     "wof:country_alpha3":"SVN",
     "wof:created":1652217711,
@@ -1255,7 +1257,7 @@
     "wof:lang_x_spoken":[
         "slv"
     ],
-    "wof:lastmodified":1694492261,
+    "wof:lastmodified":1695881374,
     "wof:name":"Slovenia",
     "wof:parent_id":102191581,
     "wof:placetype":"country",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.